### PR TITLE
Allow consul domain override

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             consul_join: consul_join,
             consul_advertise: node[:ip],
             mesos_local_address: node[:ip],
-            consul_bind_addr: node[:ip]
+            consul_bind_addr: node[:ip],
+            consul_dc: "vagrant",
           }
           ansible.groups = ansible_groups
         end
@@ -100,7 +101,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             consul_advertise: node[:ip],
             consul_is_server: false,
             mesos_local_address: node[:ip],
-            consul_bind_addr: node[:ip]
+            consul_bind_addr: node[:ip],
+            consul_dc: "vagrant",
           }
           ansible.groups = ansible_groups
         end

--- a/group_vars/all
+++ b/group_vars/all
@@ -2,3 +2,4 @@ mesos_cluster_name: "Cluster01"
 zookeeper_client_port: "2181"
 zookeeper_url: "zk://{{ groups.mesos-masters | join(':' + zookeeper_client_port + ',') }}:{{ zookeeper_client_port }}"
 mesos_local_address: "{{ansible_eth0.ipv4.address}}"
+consul_domain: consul

--- a/packer/scripts/ubuntu/install_dnsmasq.sh
+++ b/packer/scripts/ubuntu/install_dnsmasq.sh
@@ -6,4 +6,3 @@ apt-get install -y dnsmasq
 
 sudo service dnsmasq stop
 echo manual | sudo tee /etc/init/dnsmasq.override >/dev/null
-echo "server=/consul/127.0.0.1#8600" > /etc/dnsmasq.d/10-consul

--- a/packer/tests/spec/dnsmasq_spec.rb
+++ b/packer/tests/spec/dnsmasq_spec.rb
@@ -11,8 +11,3 @@ end
 describe file('/etc/init/dnsmasq.override') do
   it { should be_file }
 end
-
-describe file('/etc/dnsmasq.d/10-consul')  do
-  it { should be_file }
-  it { should contain 'server=/consul/127.0.0.1#8600' }
-end

--- a/roles/consul/templates/consul.json.j2
+++ b/roles/consul/templates/consul.json.j2
@@ -2,6 +2,7 @@
   "datacenter": "{{ consul_dc }}",
   "advertise_addr": "{{ consul_advertise }}",
   "node_name": "{{ inventory_hostname }}",
+  "domain": "{{ consul_domain }}",
   "rejoin_after_leave": true,
   "bind_addr": "{{ consul_bind_addr }}",
   "client_addr": "{{ consul_client_addr }}",

--- a/roles/dnsmasq/handlers/main.yml
+++ b/roles/dnsmasq/handlers/main.yml
@@ -1,6 +1,9 @@
 ---
 # handlers file for dnsmasq
-# Restart service dnsmasq, in all cases
 - name: Restart dnsmasq
   service: name=dnsmasq state=restarted
+  sudo: yes
+
+- name: Reload dnsmasq
+  service: name=dnsmasq state=reloaded
   sudo: yes

--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -5,3 +5,11 @@
 
 - name: ensure dnsmasq is running (and enable it at boot)
   service: name=dnsmasq state=started enabled=yes
+
+- name: configure dnsmasq
+  sudo: yes
+  template: src=10-consul.j2 dest=/etc/dnsmasq.d/10-consul owner=root group=root mode=0644
+  notify:
+    - Restart dnsmasq
+  tags:
+    - dnsmasq

--- a/roles/dnsmasq/templates/10-consul.j2
+++ b/roles/dnsmasq/templates/10-consul.j2
@@ -1,0 +1,1 @@
+server=/{{ consul_domain }}/127.0.0.1#8600


### PR DESCRIPTION
Shift the dnsmasq config out of packer and to ansible so we can override the consul domain if we need to. 
