### PR TITLE
add --local-encoding to work around bintray/wget issue with charset conversion

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: wercker/ruby
+box: ruby
 no-response-timeout: 15
 build:
   steps:
@@ -9,7 +9,7 @@ build:
         name: install packer
         cwd: packer/
         code: |
-          wget https://dl.bintray.com/mitchellh/packer/packer_0.7.5_linux_amd64.zip
+          wget --local-encoding=UTF-8 https://dl.bintray.com/mitchellh/packer/packer_0.7.5_linux_amd64.zip
           unzip packer_0.7.5_linux_amd64.zip
           ./packer version
     - script:


### PR DESCRIPTION
during `wercker build`, wget errors on download of packer with too many redirections error from bintray.com
