### PR TITLE
[terraform/aws] nat uses atalas artifact for ami

### DIFF
--- a/bootstrap/aws/config-default.sh
+++ b/bootstrap/aws/config-default.sh
@@ -9,6 +9,7 @@ ATLAS_TOKEN=${ATLAS_TOKEN:?"Need to set ATLAS_TOKEN non-empty"}
 ATLAS_INFRASTRUCTURE=${ATLAS_INFRASTRUCTURE:-capgemini/apollo}
 ATLAS_ARTIFACT_MASTER=${ATLAS_ARTIFACT_MASTER:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
 ATLAS_ARTIFACT_SLAVE=${ATLAS_ARTIFACT_SLAVE:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
+ATLAS_ARTIFACT_NAT=${ATLAS_ARTIFACT_NAT:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
 ZONE=${APOLLO_AWS_ZONE:-eu-west-1b}
 MASTER_SIZE=${MASTER_SIZE:-m1.medium}
 SLAVE_SIZE=${SLAVE_SIZE:-m1.medium}

--- a/bootstrap/aws/util.sh
+++ b/bootstrap/aws/util.sh
@@ -98,6 +98,7 @@ terraform_apply() {
       -var "instance_type.slave=${SLAVE_SIZE}" \
       -var "atlas_artifact.master=${ATLAS_ARTIFACT_MASTER}" \
       -var "atlas_artifact.slave=${ATLAS_ARTIFACT_SLAVE}" \
+      -var "atlas_artifact.nat=${ATLAS_ARTIFACT_NAT}" \
       -var "slaves=${NUM_SLAVES}" \
       -var "subnet_availability_zone=${ZONE}" \
       -var "region=${AWS_REGION}"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -63,6 +63,7 @@ variable "instance_type" {
   default = {
     master = "m1.medium"
     slave  = "m1.medium"
+    nat    = "m1.medium"
   }
 }
 
@@ -70,6 +71,7 @@ variable "atlas_artifact" {
   default = {
     master = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
     slave  = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
+    nat    = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
   }
 }
 


### PR DESCRIPTION
- previously, nat-server.tf used the default eu-west-1 ami
- this is not portable when spinning up infrastructure in any other
  region
- parameterize the nat ami similar to master/slave with an atlas
  artifact
- bubble up this parameter through the bootstrap/aws scripts