### PR TITLE
[roles/mesos] parameterize slave work_dir

### DIFF
--- a/bootstrap/aws/config-default.sh
+++ b/bootstrap/aws/config-default.sh
@@ -13,6 +13,7 @@ ZONE=${APOLLO_AWS_ZONE:-eu-west-1b}
 MASTER_SIZE=${MASTER_SIZE:-m1.medium}
 SLAVE_SIZE=${SLAVE_SIZE:-m1.medium}
 NUM_SLAVES=${NUM_SLAVES:-1}
+SLAVE_WORK_DIR=${SLAVE_WORK_DIR:-/mnt/mesos}
 
 # This removes the final character in bash (somehow)
 AWS_REGION=${ZONE%?}

--- a/bootstrap/aws/util.sh
+++ b/bootstrap/aws/util.sh
@@ -72,6 +72,7 @@ ansible_playbook_run() {
     ControlPersist=60s -F $APOLLO_ROOT/terraform/aws/ssh.config -q" \
     ansible-playbook --user=ubuntu --inventory-file=$APOLLO_ROOT/inventory/aws \
     --extra-vars "mesos_cluster_name=${MESOS_CLUSTER_NAME} \
+      mesos_slave_work_dir=${SLAVE_WORK_DIR} \
       consul_dc=${CONSUL_DC} \
       consul_atlas_infrastructure=${ATLAS_INFRASTRUCTURE} \
       consul_atlas_join=true \

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -9,3 +9,4 @@ mesos_executor_registration_timeout: 10mins
 mesos_cluster_name: "Cluster01"
 mesos_containerizers: "docker,mesos"
 mesos_resources: "ports(*):[31000-32000]"
+mesos_slave_work_dir: "/tmp/mesos"

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -95,3 +95,21 @@
   notify:
     - Start mesos slave
   when: mesos_install_mode == "slave"
+
+- name: Create Mesos Slave work area
+  file:
+    dest: "{{mesos_slave_work_dir}}"
+    mode: 0755
+    state: directory
+  sudo: yes
+  when: mesos_install_mode == "slave"
+
+- name: Set Mesos Slave work area
+  copy:
+    content: "{{mesos_slave_work_dir}}"
+    dest: /etc/mesos-slave/work_dir
+    mode: 0644
+  sudo: yes
+  notify:
+    - Start mesos slave
+  when: mesos_install_mode == "slave"


### PR DESCRIPTION
- on aws, the large ephemeral volume is mounted at /mnt by default
- without setting the slave's working dir to /mnt/X, the very small ebs
  boot volume will be filled up VERY quickly making the cluster
  unoperable.
- bubble up this parameter to the bootstrap/aws scripts