### PR TITLE
Fix #159 - Packer box versioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.box = "capgemini/apollo-mesos"
-  config.vm.box_version = conf['mesos_version']
 
   ansible_groups = {
     "mesos_masters"              => ["master1", "master2", "master3"],

--- a/docs/packer.md
+++ b/docs/packer.md
@@ -1,0 +1,106 @@
+## Packer
+
+[Packer](https://packer.io/) is used to automate the build for the base image which is used to provision everywhere.
+
+This automation includes:
+
+- installing some base level packages and config
+- installing Mesos
+- installing Consul
+- installing Weave
+- installing dnsmasq
+
+At the moment we have packer images for the following:
+
+- Vagrant
+- Google Compute Engine
+- Digitalocean
+- Amazon AMI
+
+### Building the packer images
+
+#### Vagrant
+
+To build the Vagrant image:
+
+Firstly, you will need to set the following envinronment variables
+
+```
+ATLAS_TOKEN
+```
+
+Only if you plan on using the vagrant cloud post processor to upload the box to Atlas.
+
+If you don't want to upload to Atlas you can remove the following block:
+
+```
+{
+  "type": "vagrant-cloud",
+  "box_tag": "capgemini/apollo-mesos",
+  "access_token": "{{user `access_token`}}",
+  "version": "{{user `version`}}"
+}
+```
+
+To build the box:
+
+```
+packer build ubuntu-14.04_amd64.json
+```
+
+#### AWS
+
+To build the AWS AMI:
+
+Export the following environment variables -
+
+```
+AWS_ACCESS_KEY_ID (ID for your AWS secret key)
+AWS_ACCESS_KEY (AWS secret key)
+AWS_REGION (the region to build the AMI in, e.g. eu-west-1)
+AWS_SOURCE_AMI (the source AMI to build the image off, e.g. ami-394ecc4e)
+AWS_INSTANCE_TYPE (the instance type to use to build the image, e.g. m1.medium)
+```
+
+To build the box:
+
+```
+packer build ubuntu-14.04_amd64-amis.json
+```
+
+For a complete configuration reference see [https://packer.io/docs/builders/amazon-ebs.html](https://packer.io/docs/builders/amazon-ebs.html)
+
+#### Digitalocean
+
+To build the Digitalocean image:
+
+Export the following environment variables:
+
+```
+DIGITALOCEAN_API_TOKEN (a v2 API token)
+DIGITALOCEAN_REGION (the region to build the image in, e.g. lon1)
+DIGITALOCEAN_SIZE (the size of image to use when building, e.g. 512mb)
+DIGITALOCEAN_IMAGE (the base image to use to build off, e.g. ubuntu-14-04-x64)
+```
+
+To build the box:
+
+```
+packer build ubuntu-14.04_amd64-droplet.json
+```
+For a complete configuration reference see [https://packer.io/docs/builders/digitalocean.html](https://packer.io/docs/builders/digitalocean.html)
+
+#### Google Compute Engine
+
+To build the GCE image:
+
+Export the following environment variables:
+
+```
+GCS_ACCOUNT_FILE (the JSON file containing your account credentials)
+GCS_PROJECT_ID (the project ID that will be used to launch the instance)
+GCS_SOURCE_IMAGE (the source image to build the image from, e.g. ubuntu-1404-trusty-v20150316)
+GCS_ZONE (the zone to build the image in, e.g. europe-west1-b)
+```
+
+For a complete configuration reference see [https://packer.io/docs/builders/googlecompute.html](https://packer.io/docs/builders/googlecompute.html)

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -2,25 +2,27 @@
   "variables": {
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_ACCESS_KEY`}}",
-    "mesos_version": "0.22.0-1.0.ubuntu1404",
+    "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.0",
     "weave_version": "v0.10.0",
-    "version": "0.22.0"
+    "version": "0.2.0",
+    "aws_region": "{{env `AWS_REGION`}}",
+    "aws_source_ami": "{{env `AWS_SOURCE_AMI`}}",
+    "aws_instance_type": "{{env `AWS_INSTANCE_TYPE`}}"
   },
   "builders": [{
     "type": "amazon-ebs",
-    "ami_name": "apollo-mesos-ubuntu-14.04-amd64-{{timestamp}}",
+    "ami_name": "apollo-mesos-ubuntu-14.04-amd64 {{timestamp}}",
     "ami_description": "Ubuntu 14.04 LTS, Mesos {{user `mesos_version`}}, Docker, Marathon, Consul {{user `consul_version`}}, Weave {{user `weave_version`}}, and Zookeeper.",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
-    "region": "eu-west-1",
-    "source_ami": "ami-394ecc4e",
-    "instance_type": "m1.medium",
+    "region": "{{user `aws_region`}}",
+    "source_ami": "{{user `aws_source_ami`}}",
+    "instance_type": "{{user `aws_instance_type`}}",
     "ami_groups": "all",
     "ssh_username": "ubuntu",
-    "ssh_timeout": "10m",
-    "ami_regions": ["eu-west-1"]
+    "ssh_timeout": "10m"
   }],
   "provisioners": [
     {
@@ -68,7 +70,7 @@
     "artifact_type": "aws.ami",
     "metadata": {
       "created_at": "{{timestamp}}",
-      "version": "{{user `version`}}"
+      "version": "{{user `version`}}+{{timestamp}}"
     }
   }]
 }

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -1,19 +1,20 @@
 {
   "variables": {
     "digitalocean_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
-    "digitalocean_region": "lon1",
-    "digitalocean_size": "512MB",
-    "mesos_version": "0.22.0-1.0.ubuntu1404",
+    "digitalocean_region": "{{env `DIGITALOCEAN_REGION`}}",
+    "digitalocean_size": "{{env `DIGITALOCEAN_SIZE`}}",
+    "digitalocean_image": "{{env `DIGITALOCEAN_IMAGE`}}",
+    "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.0",
     "weave_version": "v0.10.0",
-    "version": "0.22.0"
+    "version": "0.2.0"
   },
   "builders": [{
     "type": "digitalocean",
     "snapshot_name": "apollo-mesos-ubuntu-14.04-amd64",
     "api_token": "{{user `digitalocean_api_token`}}",
-    "image": "ubuntu-14-04-x64",
+    "image": "{{user `digitalocean_image`}}",
     "region": "{{user `digitalocean_region`}}",
     "size": "{{user `digitalocean_size`}}",
     "ssh_timeout": "10m"
@@ -64,7 +65,7 @@
     "artifact_type": "digitalocean.image",
     "metadata": {
       "created_at": "{{timestamp}}",
-      "version": "{{user `version`}}"
+      "version": "{{user `version`}}+{{timestamp}}"
     }
   }]
 }

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -2,10 +2,13 @@
   "variables": {
     "account_file": "{{env `GCS_ACCOUNT_FILE`}}",
     "project_id": "{{env `GCS_PROJECT_ID`}}",
-    "mesos_version": "0.22.0-1.0.ubuntu1404",
+    "source_image": "{{env `GCS_SOURCE_IMAGE`}}",
+    "zone": "{{env `GCS_ZONE`}}",
+    "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.0",
-    "weave_version": "v0.10.0"
+    "weave_version": "v0.10.0",
+    "version": "0.2.0"
   },
   "builders": [{
     "type": "googlecompute",
@@ -15,8 +18,8 @@
     "ssh_timeout": "10m",
     "account_file": "{{user `account_file`}}",
     "project_id": "{{user `project_id`}}",
-    "source_image": "ubuntu-1404-trusty-v20150316",
-    "zone": "europe-west1-b"
+    "source_image": "{{user `source_image`}}",
+    "zone": "{{user `zone`}}",
   }],
   "provisioners": [
     {
@@ -64,7 +67,7 @@
     "artifact_type": "googlecompute.image",
     "metadata": {
       "created_at": "{{timestamp}}",
-      "version": "{{user `version`}}"
+      "version": "{{user `version`}}+{{timestamp}}"
     }
   }]
 }

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -19,7 +19,7 @@
     "account_file": "{{user `account_file`}}",
     "project_id": "{{user `project_id`}}",
     "source_image": "{{user `source_image`}}",
-    "zone": "{{user `zone`}}",
+    "zone": "{{user `zone`}}"
   }],
   "provisioners": [
     {

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -3,8 +3,8 @@
     "ssh_name": "vagrant",
     "ssh_pass": "vagrant",
     "hostname": "ubuntu",
-    "version": "0.22.0",
-    "mesos_version": "0.22.0-1.0.ubuntu1404",
+    "version": "0.2.0",
+    "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.0",
     "weave_version": "v0.10.0",
@@ -86,7 +86,7 @@
       "type": "vagrant-cloud",
       "box_tag": "capgemini/apollo-mesos",
       "access_token": "{{user `access_token`}}",
-      "version": "{{user `version`}}"
+      "version": "{{user `version`}}+{{timestamp}}"
     }]
   ]
 }

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,5 +1,3 @@
-mesos_version: "0.22.0"
-
 # The numbers of servers
 #########################
 slave_n: 1       # hostname will be slave1,slave2,…


### PR DESCRIPTION
This should also tackle #160

approach i've taken follows http://semver.org/

>Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata SHOULD be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.