### PR TITLE
Rename packer / artifacts to just apollo, rather than apollo-mesos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     raise "vagrant-hosts plugin not installed"
   end
 
-  config.vm.box = "capgemini/apollo-mesos"
+  config.vm.box = "capgemini/apollo"
 
   ansible_groups = {
     "mesos_masters"              => ["master1", "master2", "master3"],

--- a/bootstrap/aws/config-default.sh
+++ b/bootstrap/aws/config-default.sh
@@ -10,8 +10,8 @@ TF_VAR_secret_key=${TF_VAR_secret_key:?"Need to set TF_VAR_secret_key non-empty"
 TF_VAR_key_file=${TF_VAR_key_file:-$HOME/.ssh/apollo_aws_rsa}
 TF_VAR_key_name=${TF_VAR_key_name:-apollo}
 
-TF_VAR_atlas_artifact_master=${TF_VAR_atlas_artifact_master:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
-TF_VAR_atlas_artifact_slave=${TF_VAR_atlas_artifact_slave:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
+TF_VAR_atlas_artifact_master=${TF_VAR_atlas_artifact_master:-capgemini/apollo-ubuntu-14.04-amd64}
+TF_VAR_atlas_artifact_slave=${TF_VAR_atlas_artifact_slave:-capgemini/apollo-ubuntu-14.04-amd64}
 
 TF_VAR_region=${TF_VAR_region%?:-eu-west-1b}
 TF_VAR_master_size=${TF_VAR_master_size:-m1.medium}

--- a/bootstrap/aws/util.sh
+++ b/bootstrap/aws/util.sh
@@ -115,9 +115,9 @@ ovpn_client_config() {
     # We need to sed the .ovpn file to replace the correct IP address, because we are getting the
     # instance IP address not the elastic IP address in the downloaded file.
     nat_ip=$(terraform output nat.ip)
-    /usr/bin/sed -i -e "s/\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}/${nat_ip}/g" $TF_VAR_user-apollo-mesos.ovpn
+    /usr/bin/sed -i -e "s/\([0-9]\{1,3\}\.\)\{3\}[0-9]\{1,3\}/${nat_ip}/g" $TF_VAR_user-apollo.ovpn
 
-    /usr/bin/open $TF_VAR_user-apollo-mesos.ovpn
+    /usr/bin/open $TF_VAR_user-apollo.ovpn
     # Display a prompt to tell the user to connect in their VPN client,
     # and pause/wait for them to connect.
     while true; do

--- a/bootstrap/digitalocean/config-default.sh
+++ b/bootstrap/digitalocean/config-default.sh
@@ -8,8 +8,8 @@ TF_VAR_region=${TF_VAR_region:-lon1}
 TF_VAR_key_file=${TF_VAR_key_file:?"Need to set TF_VAR_key_file non-empty"}
 TF_VAR_do_token=${TF_VAR_do_token:?"Need to set TF_VAR_do_token non-empty"}
 
-TF_VAR_atlas_artifact_master=${TF_VAR_atlas_artifact_master:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
-TF_VAR_atlas_artifact_slave=${TF_VAR_atlas_artifact_slave:-capgemini/apollo-mesos-ubuntu-14.04-amd64}
+TF_VAR_atlas_artifact_master=${TF_VAR_atlas_artifact_master:-capgemini/apollo-ubuntu-14.04-amd64}
+TF_VAR_atlas_artifact_slave=${TF_VAR_atlas_artifact_slave:-capgemini/apollo-ubuntu-14.04-amd64}
 TF_VAR_atlas_artifact_version_master=${TF_VAR_atlas_artifact_version_master:-1}
 TF_VAR_atlas_artifact_version_slave=${TF_VAR_atlas_artifact_version_slave:-1}
 

--- a/bootstrap/digitalocean/util.sh
+++ b/bootstrap/digitalocean/util.sh
@@ -27,8 +27,10 @@ apollo_launch() {
 }
 
 ansible_playbook_run() {
+  echo $(get_apollo_variables)
+  exit 1
   pushd $APOLLO_ROOT
-    DO_API_TOKEN=$TF_VAR_do_token ansible-playbook --user=root \
+    DO_API_TOKEN=$TF_VAR_do_token ansible-playbook -vvv --user=root \
     --inventory-file=$APOLLO_ROOT/inventory/digitalocean \
     --extra-vars "consul_atlas_infrastructure=${ATLAS_INFRASTRUCTURE} \
       consul_atlas_join=true \

--- a/bootstrap/digitalocean/util.sh
+++ b/bootstrap/digitalocean/util.sh
@@ -27,10 +27,8 @@ apollo_launch() {
 }
 
 ansible_playbook_run() {
-  echo $(get_apollo_variables)
-  exit 1
   pushd $APOLLO_ROOT
-    DO_API_TOKEN=$TF_VAR_do_token ansible-playbook -vvv --user=root \
+    DO_API_TOKEN=$TF_VAR_do_token ansible-playbook --user=root \
     --inventory-file=$APOLLO_ROOT/inventory/digitalocean \
     --extra-vars "consul_atlas_infrastructure=${ATLAS_INFRASTRUCTURE} \
       consul_atlas_join=true \

--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -32,10 +32,10 @@ replacing $ATLAS_TOKEN with your Atlas API token.
 
 This should create a build configuration under -
 
-https://atlas.hashicorp.com/YOUR_OGRANISATION/build-configurations/apollo-mesos-ubuntu-14-04-amd64
+https://atlas.hashicorp.com/YOUR_OGRANISATION/build-configurations/apollo-ubuntu-14-04-amd64
 
-The build will probably fail first time, this will be due to Atlas not having your API token. You will need to add the DIGITALOCEAN_API_TOKEN as a variable under https://atlas.hashicorp.com/YOUR_ORGANISATION/build-configurations/apollo-mesos-ubuntu-14-04-amd64/variables.
+The build will probably fail first time, this will be due to Atlas not having your API token. You will need to add the DIGITALOCEAN_API_TOKEN as a variable under https://atlas.hashicorp.com/YOUR_ORGANISATION/build-configurations/apollo-ubuntu-14-04-amd64/variables.
 
-Once your build is completed there should be a new artifact under https://atlas.hashicorp.com/YOUR_ORGANISATION/artifacts/apollo-mesos-ubuntu-14.04-amd64
+Once your build is completed there should be a new artifact under https://atlas.hashicorp.com/YOUR_ORGANISATION/artifacts/apollo-ubuntu-14.04-amd64
 
 The same steps apply if you want to create your own build configuration / artifacts for AWS/Google.

--- a/docs/packer.md
+++ b/docs/packer.md
@@ -36,7 +36,7 @@ If you don't want to upload to Atlas you can remove the following block:
 ```
 {
   "type": "vagrant-cloud",
-  "box_tag": "capgemini/apollo-mesos",
+  "box_tag": "capgemini/apollo",
   "access_token": "{{user `access_token`}}",
   "version": "{{user `version`}}"
 }

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -6,7 +6,7 @@
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
-    "version": "0.2.0",
+    "version": "0.1.1",
     "aws_region": "{{env `AWS_REGION`}}",
     "aws_source_ami": "{{env `AWS_SOURCE_AMI`}}",
     "aws_instance_type": "{{env `AWS_INSTANCE_TYPE`}}"

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -13,7 +13,7 @@
   },
   "builders": [{
     "type": "amazon-ebs",
-    "ami_name": "apollo-mesos-ubuntu-14.04-amd64 {{timestamp}}",
+    "ami_name": "apollo-ubuntu-14.04-amd64 {{timestamp}}",
     "ami_description": "Ubuntu 14.04 LTS, Mesos {{user `mesos_version`}}, Docker, Marathon, Consul {{user `consul_version`}}, Weave {{user `weave_version`}}, and Zookeeper.",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
@@ -62,11 +62,11 @@
     }
   ],
   "push": {
-    "name": "capgemini/apollo-mesos-ubuntu-14-04-amd64"
+    "name": "capgemini/apollo-ubuntu-14-04-amd64"
   },
   "post-processors": [{
     "type": "atlas",
-    "artifact": "capgemini/apollo-mesos-ubuntu-14.04-amd64",
+    "artifact": "capgemini/apollo-ubuntu-14.04-amd64",
     "artifact_type": "aws.ami",
     "metadata": {
       "created_at": "{{timestamp}}",

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -4,7 +4,7 @@
     "aws_secret_key": "{{env `AWS_ACCESS_KEY`}}",
     "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
-    "consul_version": "0.5.0",
+    "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
     "version": "0.2.0",
     "aws_region": "{{env `AWS_REGION`}}",

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -62,7 +62,7 @@
     }
   ],
   "push": {
-    "name": "capgemini/apollo-ubuntu-14-04-amd64"
+    "name": "capgemini/apollo"
   },
   "post-processors": [{
     "type": "atlas",

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -8,7 +8,7 @@
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
-    "version": "0.2.0"
+    "version": "0.1.1"
   },
   "builders": [{
     "type": "digitalocean",

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -12,7 +12,7 @@
   },
   "builders": [{
     "type": "digitalocean",
-    "snapshot_name": "apollo-mesos-ubuntu-14.04-amd64",
+    "snapshot_name": "apollo-ubuntu-14.04-amd64",
     "api_token": "{{user `digitalocean_api_token`}}",
     "image": "{{user `digitalocean_image`}}",
     "region": "{{user `digitalocean_region`}}",
@@ -57,11 +57,11 @@
     }
   ],
   "push": {
-    "name": "capgemini/apollo-mesos-ubuntu-14-04-amd64"
+    "name": "capgemini/apollo-ubuntu-14-04-amd64"
   },
   "post-processors": [{
     "type": "atlas",
-    "artifact": "capgemini/apollo-mesos-ubuntu-14.04-amd64",
+    "artifact": "capgemini/apollo-ubuntu-14.04-amd64",
     "artifact_type": "digitalocean.image",
     "metadata": {
       "created_at": "{{timestamp}}",

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -57,7 +57,7 @@
     }
   ],
   "push": {
-    "name": "capgemini/apollo-ubuntu-14-04-amd64"
+    "name": "capgemini/apollo"
   },
   "post-processors": [{
     "type": "atlas",

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -6,7 +6,7 @@
     "digitalocean_image": "{{env `DIGITALOCEAN_IMAGE`}}",
     "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
-    "consul_version": "0.5.0",
+    "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
     "version": "0.2.0"
   },

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -12,7 +12,7 @@
   },
   "builders": [{
     "type": "googlecompute",
-    "image_name": "apollo-mesos-ubuntu-14.04-amd64",
+    "image_name": "apollo-ubuntu-14.04-amd64",
     "image_description": "Ubuntu 14.04 LTS, Meosos {{user `mesos_version`}}, Docker, Marathon, Consul {{user `consul_version`}}, Weave {{user `weave_version`}}, and Zookeeper.",
     "ssh_username": "ubuntu",
     "ssh_timeout": "10m",
@@ -59,11 +59,11 @@
     }
   ],
   "push": {
-    "name": "capgemini/apollo-mesos-ubuntu-14-04-amd64"
+    "name": "capgemini/apollo"
   },
   "post-processors": [{
     "type": "atlas",
-    "artifact": "capgemini/apollo-mesos-ubuntu-14.04-amd64",
+    "artifact": "capgemini/apollo-ubuntu-14.04-amd64",
     "artifact_type": "googlecompute.image",
     "metadata": {
       "created_at": "{{timestamp}}",

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -8,7 +8,7 @@
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
-    "version": "0.2.0"
+    "version": "0.1.1"
   },
   "builders": [{
     "type": "googlecompute",

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -6,7 +6,7 @@
     "zone": "{{env `GCS_ZONE`}}",
     "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
-    "consul_version": "0.5.0",
+    "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
     "version": "0.2.0"
   },

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -3,7 +3,7 @@
     "ssh_name": "vagrant",
     "ssh_pass": "vagrant",
     "hostname": "ubuntu",
-    "version": "0.2.0",
+    "version": "0.1.1",
     "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
     "consul_version": "0.5.1",

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -16,7 +16,7 @@
     "type": "virtualbox-iso",
     "guest_os_type": "Ubuntu_64",
     "headless": true,
-    "vm_name": "apollo-mesos-ubuntu-14.04-amd64-virtualbox",
+    "vm_name": "apollo-ubuntu-14.04-amd64-virtualbox",
     "disk_size": 40960,
     "vboxmanage": [
       [ "modifyvm", "{{.Name}}", "--memory", "2048" ],
@@ -50,7 +50,7 @@
     "type": "vmware-iso",
     "guest_os_type": "linux",
     "headless": true,
-    "vm_name": "apollo-mesos-ubuntu-14.04-amd64-vmware",
+    "vm_name": "apollo-ubuntu-14.04-amd64-vmware",
     "disk_size": 40960,
     "vmx_data": {
       "memsize": "2048",
@@ -119,7 +119,7 @@
     },
     {
       "type": "vagrant-cloud",
-      "box_tag": "capgemini/apollo-mesos",
+      "box_tag": "capgemini/apollo",
       "access_token": "{{user `access_token`}}",
       "version": "{{user `version`}}+{{timestamp}}"
     }]

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -124,7 +124,7 @@
       "type": "vagrant-cloud",
       "box_tag": "capgemini/apollo",
       "access_token": "{{user `access_token`}}",
-      "version": "{{user `version`}}+{{timestamp}}"
+      "version": "{{user `version`}}"
     }]
   ]
 }

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -6,7 +6,7 @@
     "version": "0.2.0",
     "mesos_version": "0.22.1-1.0.ubuntu1404",
     "marathon_version": "0.8.1-1.0.171.ubuntu1404",
-    "consul_version": "0.5.0",
+    "consul_version": "0.5.1",
     "weave_version": "v0.10.0",
     "access_token": "{{env `ATLAS_TOKEN`}}",
     "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.2-server-amd64.iso",

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -110,10 +110,13 @@
       "execute_command": "echo '{{user `ssh_pass`}}' | {{ .Vars }} sudo -E -S bash -c '{{ .Path }}'"
     }
   ],
+  "push": {
+    "name": "capgemini/apollo"
+  },
   "post-processors": [
     [{
       "type": "vagrant",
-      "output": "build/ubuntu-14.04_amd64_{{.Provider}}/apollo-mesos-ubuntu-14.04-amd64-{{.Provider}}.box",
+      "output": "build/ubuntu-14.04_amd64_{{.Provider}}/apollo-ubuntu-14.04-amd64-{{.Provider}}.box",
       "keep_input_artifact": true,
       "compression_level": 9
     },

--- a/terraform/aws/bin/ovpn-client-config
+++ b/terraform/aws/bin/ovpn-client-config
@@ -1,1 +1,1 @@
-ssh -t "ubuntu@$(terraform output nat.ip)" sudo docker run --volumes-from ovpn-data --rm gosuri/openvpn ovpn_getclient "${1}" > "${1}-apollo-mesos.ovpn"
+ssh -t "ubuntu@$(terraform output nat.ip)" sudo docker run --volumes-from ovpn-data --rm gosuri/openvpn ovpn_getclient "${1}" > "${1}-apollo.ovpn"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -82,8 +82,8 @@ variable "instance_type" {
 
 variable "atlas_artifact" {
   default = {
-    master = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
-    slave  = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
+    master = "capgemini/apollo-ubuntu-14.04-amd64"
+    slave  = "capgemini/apollo-ubuntu-14.04-amd64"
   }
 }
 

--- a/terraform/digitalocean/variables.tf
+++ b/terraform/digitalocean/variables.tf
@@ -33,8 +33,8 @@ variable "instance_size" {
 
 variable "atlas_artifact" {
   default = {
-    master = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
-    slave  = "capgemini/apollo-mesos-ubuntu-14.04-amd64"
+    master = "capgemini/apollo-ubuntu-14.04-amd64"
+    slave  = "capgemini/apollo-ubuntu-14.04-amd64"
   }
 }
 


### PR DESCRIPTION
BIG FAT BREAKING CHANGE.

We need to rebuild all artifacts in correlation with this PR as it changes ```apollo-mesos``` to just ```apollo``` in most of those.

Suggest we keep the artifacts at apollo-mesos in the vagrantcloud and atlas anyway for a bit so we dont break people on 0.1