### PR TITLE
Deploy docker/weave/registrator to all hosts

### DIFF
--- a/inventory/aws/inventory
+++ b/inventory/aws/inventory
@@ -23,5 +23,6 @@ mesos_masters
 mesos_masters
 
 [weave_servers:children]
+mesos_masters
 mesos_slaves
 load_balancers

--- a/inventory/digitalocean/inventory
+++ b/inventory/digitalocean/inventory
@@ -17,5 +17,6 @@ mesos_masters
 mesos_masters
 
 [weave_servers:children]
+mesos_masters
 mesos_slaves
 load_balancers

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,9 @@
   roles:
     - dnsmasq
     - consul
+    - docker
+    - weave
+    - registrator
 
 - hosts: mesos_masters
   vars:
@@ -14,16 +17,10 @@
 
 - hosts: mesos_slaves
   roles:
-    - docker
     - { role: mesos, mesos_install_mode: "slave", tags: ["mesos-slave"] }
-    - weave
-    - registrator
 
 - hosts: load_balancers
   roles:
-    - docker
-    - weave
-    - registrator
     - haproxy
 
 - include: tests/test.yml

--- a/tests/properties.yml
+++ b/tests/properties.yml
@@ -4,6 +4,8 @@ mesos_masters:
     - mesos_master
     - marathon
     - zookeeper
+    - weave
+    - docker
 mesos_slaves:
   :roles:
     - dnsmasq


### PR DESCRIPTION
Sets the weave network to be across the entire cluster and installs docker/registrator on the masters too. This should allow us to launch containers there (which we're probably going to want to do)