### PR TITLE
updating weave url since project moved to weaveworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Apollo is built on top of the following components:
 * [Apache Mesos](http://mesos.apache.org/) for cluster management, scheduling and resource isolation
 * [Consul](http://consul.io) for service discovery, DNS
 * [Docker](http://docker.io) for application container runtimes
-* [Weave](https://github.com/zettio/weave) for networking of docker containers
+* [Weave](https://github.com/weaveworks/weave) for networking of docker containers
 * [HAProxy](http://www.haproxy.org) for application container load balancing
 
 Apollo is:

--- a/packer/scripts/common/install_weave.sh
+++ b/packer/scripts/common/install_weave.sh
@@ -3,6 +3,6 @@ set -eux
 set -o pipefail
 
 sudo wget -O /usr/local/bin/weave \
-    https://github.com/zettio/weave/releases/download/${WEAVE_VERSION}/weave
+    https://github.com/weaveworks/weave/releases/download/${WEAVE_VERSION}/weave
 sudo chmod a+x /usr/local/bin/weave
 


### PR DESCRIPTION
Zettio has removed the project from his user account and set it up under the organisation 'weaveworks'. Pull request to fix the urls and packer script