### PR TITLE
[roles/registrator] remove vestigial hostname

### DIFF
--- a/roles/registrator/defaults/main.yml
+++ b/roles/registrator/defaults/main.yml
@@ -2,5 +2,4 @@
 # defaults file for registrator
 registrator_image: "gliderlabs/registrator:master"
 registrator_uri: "consul://{{ ansible_default_ipv4.address }}:8500"
-hostname: "{{ ansible_all_ipv4_addresses }}"
 

--- a/roles/registrator/tasks/main.yml
+++ b/roles/registrator/tasks/main.yml
@@ -16,7 +16,6 @@
     restart_policy: always
     net: host
     command: "-internal {{ registrator_uri }}"
-    hostname: "{{ hostname }}"
     volumes:
     - "/var/run/docker.sock:/tmp/docker.sock"
   tags:


### PR DESCRIPTION
- setting `hostname` is incompatible with `net: host`
- `ansible_all_ipv4_addresses` yields an invalid value for `hostname`