### PR TITLE
[roles] use service module for starts/restarts

### DIFF
--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 # handlers file for docker
 - name: Restart docker
-  shell: restart docker
+  service: name=docker state=restarted
   sudo: yes

--- a/roles/marathon/handlers/main.yml
+++ b/roles/marathon/handlers/main.yml
@@ -3,4 +3,4 @@
 # Restart service marathon, in all cases
 - name: Restart marathon
   sudo: yes
-  shell: /sbin/restart marathon
+  service: name=marathon state=restarted

--- a/roles/mesos/handlers/main.yml
+++ b/roles/mesos/handlers/main.yml
@@ -1,17 +1,17 @@
 ---
 # handlers file for mesos
 - name: Start mesos master
-  shell: start mesos-master
   sudo: yes
+  service: name=mesos-master state=started
 
 - name: Start mesos slave
-  shell: start mesos-slave
   sudo: yes
+  service: name=mesos-slave state=started
 
 - name: Restart mesos master
-  shell: restart mesos-master
   sudo: yes
+  service: name=mesos-master state=restarted
 
 - name: Restart mesos slave
-  shell: restart mesos-slave
   sudo: yes
+  service: name=mesos-slave state=restarted

--- a/roles/zookeeper/handlers/main.yml
+++ b/roles/zookeeper/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 # handlers file for zookeeper
 - name: Restart zookeeper
-  shell: restart zookeeper
+  service: name=zookeeper state=restarted
   sudo: yes
 
 - name: Start zookeeper
-  shell: start zookeeper
+  service: name=zookeeper state=started
   sudo: yes


### PR DESCRIPTION
The shell module as used is not idempotent, use the service module -
built-in idempotency and portable.