### PR TITLE
[roles/docker+weave] opt. set graph and tmp dirs

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for docker
+docker_graph_dir: /var/lib/docker
+docker_tmp_dir: /var/lib/docker/tmp

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -7,6 +7,21 @@
   tags:
     - docker
 
+- name: configure docker graph directory
+  sudo: yes
+  lineinfile:
+    dest: /etc/default/docker
+    state: present
+    regexp: ^DOCKER_OPTS=.*--graph.*
+    line: 'DOCKER_OPTS=\"$DOCKER_OPTS --graph={{ docker_graph_dir }}\"'
+
+- name: configure docker temporary directory
+  sudo: yes
+  lineinfile:
+    dest: /etc/default/docker
+    state: present
+    line: 'DOCKER_TMPDIR=\"{{ docker_tmp_dir }}\"'
+
 - name: ensure docker is running (and enable it at boot)
   service:
     name: docker

--- a/roles/weave/tasks/main.yml
+++ b/roles/weave/tasks/main.yml
@@ -48,8 +48,8 @@
   lineinfile:
     dest: /etc/default/docker
     state: present
-    regexp: ^DOCKER_OPTS=
-    line: 'DOCKER_OPTS=\"{{ weave_docker_opts }}\"'
+    regexp: ^DOCKER_OPTS=.*--bridge=weave.*
+    line: 'DOCKER_OPTS=\"$DOCKER_OPTS {{ weave_docker_opts }}\"'
   notify:
     - Restart docker
   tags:


### PR DESCRIPTION
- this is optional and defaults are only  over-ridden if the following
  env vars are defined:
        - `APOLLO_docker_graph_dir`
        - `APOLLO_docker_tmp_dir`
- needed because for many ec2 instances, the large ephemeral volume is
  mounted under /mnt and the boot volume is very small
- rework the lineinfile calls to be idempotent
- rework the lineinfile call in docker and weave so
  DOCKER_OPTS directive is accumulative