### PR TITLE
Use vagrant-hostmanager instead of vagrant-hosts plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,12 +16,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.cache.enable :apt
   end
 
-  # throw error if vagrant-hosts not installed
-  unless Vagrant.has_plugin?("vagrant-hosts")
-    raise "vagrant-hosts plugin not installed"
+  # throw error if vagrant-hostmanager not installed
+  unless Vagrant.has_plugin?("vagrant-hostmanager")
+    raise "vagrant-hostmanager plugin not installed"
   end
 
   config.vm.box = "capgemini/apollo"
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.include_offline = true
 
   ansible_groups = {
     "mesos_masters"              => ["master1", "master2", "master3"],
@@ -64,7 +67,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cfg.vm.provider :virtualbox do |vb, override|
         override.vm.hostname = node[:hostname]
         override.vm.network :private_network, :ip => node[:ip]
-        override.vm.provision :hosts
 
         vb.name = 'vagrant-mesos-' + node[:hostname]
         vb.customize ["modifyvm", :id, "--memory", node[:mem], "--cpus", node[:cpus] ]
@@ -97,7 +99,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cfg.vm.provider :virtualbox do |vb, override|
         override.vm.hostname = node[:hostname]
         override.vm.network :private_network, :ip => node[:ip]
-        override.vm.provision :hosts
 
         vb.name = 'vagrant-mesos-' + node[:hostname]
         vb.customize ["modifyvm", :id, "--memory", node[:mem], "--cpus", node[:cpus] ]

--- a/docs/getting-started-guides/vagrant.md
+++ b/docs/getting-started-guides/vagrant.md
@@ -5,7 +5,7 @@ Running Apollo with Vagrant (and Virtualbox) is an easy way to run/test/develop 
 ### Prerequisites
 
 1. The latest version of vagrant installed (>= 1.7.2) [http://www.vagrantup.com/downloads.html](http://www.vagrantup.com/downloads.html) to get started
-2. Install vagrant-hosts plugin ```vagrant plugin install vagrant-hosts```
+2. Install vagrant-hostmanager plugin ```vagrant plugin install vagrant-hostmanager```
 3. The latest version of Virtualbox from [https://www.virtualbox.org/wiki/Downloads](https://www.virtualbox.org/wiki/Downloads)
 4. You need to have [Python](https://www.python.org/) >= 2.7.5 installed along with [pip](https://pip.pypa.io/en/latest/installing.html).
 
@@ -32,9 +32,9 @@ Vagrant will set up a 3 node mesos-master cluster and 1 mesos-slave. By default 
 
 By default the web interfaces should be available on -
 
-- [http://172.31.1.11:5050](http://172.31.1.11:5050) (Mesos)
-- [http://172.31.1.11:8080](http://172.31.1.11:8080) (Marathon)
-- [http://172.31.1.11:8500](http://172.31.1.11:8500) (Consul)
+- [http://master1:5050](http://master1:5050) (Mesos)
+- [http://master1:8080](http://master1:8080) (Marathon)
+- [http://master1:8500](http://master1:8500) (Consul)
 
 Mesos / Marathon should handle redirection the the leader node automatically via Zookeeper.
 


### PR DESCRIPTION
This plugin actually supports updating the host machines /etc/hosts (the other one only does the guests). This plugin also more supported/used in the community and seems to work better than vagrant-hosts