### PR TITLE
Ensure we use common instance_type instead of _size across the board

### DIFF
--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -115,8 +115,8 @@ get_ansible_inventory() {
 terraform_apply() {
   pushd "${APOLLO_ROOT}/terraform/${APOLLO_PROVIDER}"
     # This variables need to be harcoded as Terraform does not support environment overriding for Mappings at the moment.
-    terraform apply -var "instance_size.master=${TF_VAR_master_size}" \
-      -var "instance_size.slave=${TF_VAR_slave_size}" \
+    terraform apply -var "instance_type.master=${TF_VAR_master_size}" \
+      -var "instance_type.slave=${TF_VAR_slave_size}" \
       -var "atlas_artifact_version.master=${TF_VAR_atlas_artifact_version_master}" \
       -var "atlas_artifact_version.slave=${TF_VAR_atlas_artifact_version_slave}" \
       -var "atlas_artifact.master=${TF_VAR_atlas_artifact_master}" \

--- a/terraform/digitalocean/mesos-masters.tf
+++ b/terraform/digitalocean/mesos-masters.tf
@@ -17,7 +17,7 @@ resource "digitalocean_droplet" "mesos-master" {
   region             = "${var.region}"
   count              = "${var.masters}"
   name               = "apollo-mesos-master-${count.index}"
-  size               = "${var.instance_size.master}"
+  size               = "${var.instance_type.master}"
   depends_on         = ["digitalocean_ssh_key.default"]
   private_networking = true
   user_data          = "{role: mesos_masters}"

--- a/terraform/digitalocean/mesos-slaves.tf
+++ b/terraform/digitalocean/mesos-slaves.tf
@@ -11,7 +11,7 @@ resource "digitalocean_droplet" "mesos-slave" {
   region             = "${var.region}"
   count              = "${var.slaves}"
   name               = "apollo-mesos-slave-${count.index}"
-  size               = "${var.instance_size.slave}"
+  size               = "${var.instance_type.slave}"
   depends_on         = ["digitalocean_droplet.mesos-master"]
   private_networking = true
   user_data          = "{role: mesos_slaves}"

--- a/terraform/digitalocean/variables.tf
+++ b/terraform/digitalocean/variables.tf
@@ -24,7 +24,7 @@ variable "slaves" {
   default = "1"
 }
 
-variable "instance_size" {
+variable "instance_type" {
   default = {
     master = "512mb"
     slave  = "512mb"


### PR DESCRIPTION
In AWS/GCE we do something like - 

```
variable "instance_type" {
  default = {
    master = "n1-standard-2"
    slave  = "n1-standard-2"
  }
}
```

however in DO we were using ```instance_size```. This PR just standardises across the board, as we were unable to change the AWS ones.