### PR TITLE
Fix #289 & Improve Drupal examples and documentation 

### DIFF
--- a/examples/drupal-mysql/README.md
+++ b/examples/drupal-mysql/README.md
@@ -2,42 +2,57 @@
 
 This example shows how to deploy a multi-tier Drupal web app using Apollo and Marathon Mesos framework.
 
-The example includes -
+| Example                 | Description                                  | Example URL
+|-------------------------|----------------------------------------------|--------------------------
+| commerce-kickstart.json | Commerce kickstart web container, with mysql  backend container | commerce-kickstart.example.com
+| drupal7.json            | Drupal7 bare web container, with mysql backend container | drupal7.example.com
+| drupal8.json            | Drupal8 bare web container, with mysql backend container | drupal8.example.com
 
-* A web frontend (Using Drupal Commerce Kickstart distribution)
+These examples includes -
+
+* A web frontend (Using Drupal7/Drupal8/Drupal Commerce Kickstart distribution)
 * A MySQL (5.5) backend
+
+Each example is very similar, for the purposes of this document we will explain how to get the Commerce Kickstart application up and running. The same steps apply for Drupal7 and Drupal8 core.
 
 We'll use the [mysql](https://registry.hub.docker.com/_/mysql/) official [Docker](https://www.docker.com/) image and an [apollo-commerce-kickstart](https://registry.hub.docker.com/u/capgemini/apollo-commerce-kickstart/) image which contains [php-apache](https://registry.hub.docker.com/_/php/), Drush and [Commerce Kickstart](https://www.drupal.org/project/commerce_kickstart).
 
 The examples are to be deployed on top of the Marathon Mesos framework.
 
-### Start the Drupal and MySQL services
+### Start the services
 
-First, edit ```drupal-mysql.json```, in the mysql app service definition, to use database credentials that you specify (or leave as is if you are happy and this is just for demo purposes).
+First, edit ```commerce-kickstart.json```, in the mysql app service definition, to use database credentials that you specify (or leave as is if you are happy and this is just for demo purposes).
 
-If you changed the database credentials as above, then edit the drupal app definition in ```drupal-mysql.json```, to use database credentials that you specify (or leave as is if you are happy and this is just for demo purposes).
+If you changed the database credentials as above, then edit the drupal app definition in ```commerce-kickstart.json```, to use database credentials that you specify (or leave as is if you are happy and this is just for demo purposes).
 
 Start the services by running the following command (from somewhere you can access the REST interface of Marathon). Replace $MARATHON_IP with the actual hostname/ip address of the marathon instance.
 Marathon by default should be deployed in the ```mesos_master``` nodes.
 
 ```
-curl -X POST -HContent-Type:application/json -d @drupal-mysql.json $MARATHON_IP:8080/v2/groups
+curl -X POST -HContent-Type:application/json -d @commerce-kickstart.json $MARATHON_IP:8080/v2/groups
 ```
 
-This should spin up a separate Drupal Docker container that is communicating to the MySQL container using the Consul DNS address ```mysql.service.consul``` by default.
+This should spin up a separate Drupal Docker container that is communicating to the MySQL container using the Consul DNS address ```commerce-kickstart.mysql.service.consul``` by default.
 
-The service will be accessible through the HAProxy container (on port 80) at ```drupal.example.com``` by default. It is recommended that you set up your own DNS servers / hostname and override the ```haproxy_domain``` in [../roles/haproxy/defaults/main.yml](../roles/haproxy/defaults/main.yml).
+The service will be accessible through the HAProxy container (on port 80) at ```commerce-kickstart.example.com``` by default. It is recommended that you set up your own DNS servers / hostname and override the ```haproxy_domain``` in [../roles/haproxy/defaults/main.yml](../roles/haproxy/defaults/main.yml).
 
 ### For cloud instances
 
-To access the Drupal site, go to the Marathon dashboard at ```http://$MARATHON_IP:8080/#apps``` and click on ```/drupal-mysql-example/drupal```. You should see an IP address and Port in the service definition, if you click on it you should be redirected to the Drupal installation screen.
+If you are running the application in the cloud make sure you have enough compute power in your cluster to handle the web applications and the databases. We have tested running up the following example in AWS on a 5 node cluster (3 master / 2 slave) using ```c3.large``` compute instances, which work well enough for demo purposes.
+
+To access the Drupal site, you will either need to have DNS set up or map either the ELB or the slave instance IP to your ```/etc/hosts``` file. Go grab the IP address and map it to
+
+
+```
+SLAVE_IP_HOST commerce-kickstart.example.com
+```
 
 ### For Vagrant only
 
 If you are deploying this example in the Vagrant environment, simply add the following entry to your host machine in ```/etc/hosts```
 
 ```
-172.31.1.14 drupal.example.com
+172.31.1.14 commerce-kickstart.example.com
 ```
 
 Where ```172.31.1.14``` is the Slave IP address configured in ```vagrant.yml```
@@ -48,18 +63,18 @@ running on the slave machine which will forward the traffic to the Drupal docker
 
 By default the database will not be pre-populated. To install the site either:
 
-1. Navigate to ```drupal.example.com``` (or whatever you have your DNS set up as) and follow the on-screen instructions to install the site
+1. Navigate to ```commerce-kickstart.example.com``` (or whatever you have your DNS set up as) and follow the on-screen instructions to install the site
 2. Login to the docker container and install the site via Drush. To do this -
   - Navigate to the slave machine the container is running on
   - Get the container id: ```docker ps | grep drupal```
   - Login to the container: ```docker exec -it $CONTAINER_ID /bin/bash```
   - Install the site:
-  ```drush site-install commerce_kickstart --site-name=default --acount-pass=changeme -y```
+  ```drush site-install commerce_kickstart --site-name=default --account-pass=changeme -y```
 
 ### Removing the apps
 
 You can remove the applications straight from the command line by running -
 
 ```
-curl -XDELETE http://$MARATHON_IP:8080/v2/groups/drupal-mysql-example
+curl -XDELETE http://$MARATHON_IP:8080/v2/groups/commerce-kickstart
 ```

--- a/examples/drupal-mysql/commerce-kickstart.json
+++ b/examples/drupal-mysql/commerce-kickstart.json
@@ -1,0 +1,51 @@
+{
+  "id": "commerce-kickstart",
+  "apps": [
+    {
+      "id": "mysql",
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "mysql:5.5",
+          "network": "BRIDGE"
+        }
+      },
+      "env": {
+        "SERVICE_NAME": "mysql",
+        "SERVICE_TAGS": "commerce-kickstart",
+        "MYSQL_DATABASE": "commerce-kickstart",
+        "MYSQL_USER": "ckuser",
+        "MYSQL_PASSWORD": "ckuser",
+        "MYSQL_ROOT_PASSWORD": "password"
+      },
+      "cpus": 1,
+      "mem": 1024.0,
+      "instances": 1
+    },
+    {
+      "id": "web",
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "capgemini/apollo-commerce-kickstart:latest",
+          "network": "BRIDGE",
+          "portMappings": [{
+            "containerPort": 80,
+            "hostPort": 0,
+            "protocol": "tcp"
+          }]
+        }
+      },
+      "env": {
+        "SERVICE_NAME": "commerce-kickstart",
+        "DRUPAL_DB_PASSWORD": "password",
+        "DRUPAL_DB_NAME": "commerce-kickstart",
+        "DRUPAL_DB_HOST": "commerce-kickstart.mysql.service.consul"
+      },
+      "cpus": 1,
+      "mem": 512.0,
+      "instances": 1,
+      "dependencies": ["/commerce-kickstart/mysql"]
+    }
+  ]
+}

--- a/examples/drupal-mysql/drupal7.json
+++ b/examples/drupal-mysql/drupal7.json
@@ -1,5 +1,5 @@
 {
-  "id": "drupal-mysql-example",
+  "id": "drupal-7",
   "apps": [
     {
       "id": "mysql",
@@ -7,31 +7,27 @@
         "type": "DOCKER",
         "docker": {
           "image": "mysql:5.5",
-          "network": "BRIDGE",
-          "portMappings": [{
-            "containerPort": 3306,
-            "hostPort": 0,
-            "protocol": "tcp"
-          }]
-        }
+          "network": "BRIDGE"
+        },
       },
       "env": {
         "SERVICE_NAME": "mysql",
-        "MYSQL_DATABASE": "drupal",
-        "MYSQL_USER": "drupal",
-        "MYSQL_PASSWORD": "drupal",
+        "SERVICE_TAGS": "drupal7",
+        "MYSQL_DATABASE": "drupal7",
+        "MYSQL_USER": "drupal7",
+        "MYSQL_PASSWORD": "drupal7",
         "MYSQL_ROOT_PASSWORD": "password"
       },
       "cpus": 1,
-      "mem": 256.0,
+      "mem": 1024.0,
       "instances": 1
     },
     {
-      "id": "drupal",
+      "id": "drupal7",
       "container": {
         "type": "DOCKER",
         "docker": {
-          "image": "capgemini/apollo-commerce-kickstart:latest",
+          "image": "drupal:7",
           "network": "BRIDGE",
           "portMappings": [{
             "containerPort": 80,
@@ -41,13 +37,13 @@
         }
       },
       "env": {
-        "SERVICE_NAME": "drupal",
+        "SERVICE_NAME": "drupal7",
         "DRUPAL_DB_PASSWORD": "password",
-        "DRUPAL_DB_NAME": "drupal",
-        "DRUPAL_DB_HOST": "mysql.service.consul"
+        "DRUPAL_DB_NAME": "drupal7",
+        "DRUPAL_DB_HOST": "drupal7.mysql.service.consul"
       },
-      "cpus": 0.5,
-      "mem": 128.0,
+      "cpus": 1,
+      "mem": 512.0,
       "instances": 1,
       "healthChecks": [{
         "path": "/",
@@ -58,7 +54,7 @@
         "timeoutSeconds": 20,
         "maxConsecutiveFailures": 3
       }],
-      "dependencies": ["/drupal-mysql-example/mysql"]
+      "dependencies": ["/drupal-7/mysql"]
     }
   ]
 }

--- a/examples/drupal-mysql/drupal8.json
+++ b/examples/drupal-mysql/drupal8.json
@@ -1,0 +1,60 @@
+{
+  "id": "drupal-8",
+  "apps": [
+    {
+      "id": "mysql",
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "mysql:5.5",
+          "network": "BRIDGE"
+        }
+      },
+      "env": {
+        "SERVICE_NAME": "mysql",
+        "SERVICE_TAGS": "drupal8",
+        "MYSQL_DATABASE": "drupal8",
+        "MYSQL_USER": "drupal8",
+        "MYSQL_PASSWORD": "drupal8",
+        "MYSQL_ROOT_PASSWORD": "password"
+      },
+      "cpus": 1,
+      "mem": 1024.0,
+      "instances": 1
+    },
+    {
+      "id": "drupal8",
+      "container": {
+        "type": "DOCKER",
+        "docker": {
+          "image": "drupal:8",
+          "network": "BRIDGE",
+          "portMappings": [{
+            "containerPort": 80,
+            "hostPort": 0,
+            "protocol": "tcp"
+          }]
+        }
+      },
+      "env": {
+        "SERVICE_NAME": "drupal8",
+        "DRUPAL_DB_PASSWORD": "password",
+        "DRUPAL_DB_NAME": "drupal8",
+        "DRUPAL_DB_HOST": "drupal8.mysql.service.consul"
+      },
+      "cpus": 1,
+      "mem": 512.0,
+      "instances": 1,
+      "healthChecks": [{
+        "path": "/",
+        "portIndex": 0,
+        "protocol": "HTTP",
+        "gracePeriodSeconds": 30,
+        "intervalSeconds": 10,
+        "timeoutSeconds": 20,
+        "maxConsecutiveFailures": 3
+      }],
+      "dependencies": ["/drupal-8/mysql"]
+    }
+  ]
+}


### PR DESCRIPTION
- Improve docs around cloud requirements
- Use marathon groups to launch
- Add drupal7 / drupal 8 JSON files

This fixes #289 

Tested on a c3.large cluster in AWS.