### PR TITLE
fix awk error in get_apollo_variables

### DIFF
--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -59,7 +59,7 @@ get_apollo_variables() {
     # This deletes shortest match of $substring from front of $string. ${string#substring}
     var_value=${env_var#${plugin_namespace}}
 
-    var=$( echo "${var_value}" | awk -F = '{ print "${1}" }' )
+    var=$( echo "${var_value}" | awk -F = '{ print $1 }' )
     value=${var_value#*=}
     var_list+=( "${var}='${value}'" )
   done


### PR DESCRIPTION
This prints a literal `${1}` instead of the value of the first column.

bash refactor commit broke passing APOLLO_* env vars to ansible
5cf39b6a5366d3084c4e113926178f3c7ed34a00
https://github.com/Capgemini/Apollo/blob/5cf39b6a5366d3084c4e113926178f3c7ed34a00/bootstrap/common.sh#L62