### PR TITLE
[packer] make sure docker is using aufs

### DIFF
--- a/packer/scripts/ubuntu/install_docker.sh
+++ b/packer/scripts/ubuntu/install_docker.sh
@@ -3,6 +3,7 @@ set -eux
 set -o pipefail
 
 sudo apt-get -y update
+sudo apt-get install -y linux-image-extra-$(uname -r)
 curl -sSL https://get.docker.com/ubuntu/ | sudo sh
 sudo service docker stop
 echo manual | sudo tee /etc/init/docker.override >/dev/null

--- a/packer/tests/spec/docker_spec.rb
+++ b/packer/tests/spec/docker_spec.rb
@@ -4,6 +4,10 @@ describe package('lxc-docker') do
   it { should be_installed }
 end
 
+describe package("linux-image-extra-#{`uname -r`.strip}") do
+  it { should be_installed }
+end
+
 describe service('docker') do
   it { should_not be_running }
 end


### PR DESCRIPTION
(context https://github.com/Capgemini/Apollo/issues/315)
- aufs drivers aren't installed by default on Trusty cloud images, which
  causes docker to fall back to devicemapper.  This is bad because
  devicemapper is completely broken on Trusty