### PR TITLE
Remove -iprange parameter as it is causing weave networking issues in AWS

### DIFF
--- a/roles/weave/templates/weave.conf.j2
+++ b/roles/weave/templates/weave.conf.j2
@@ -10,7 +10,7 @@ pre-start exec ${WEAVE} stop
 
 script
  [ -e /etc/default/weave ] && . /etc/default/weave
- ${WEAVE} launch -iprange "{{ weave_docker_subnet }}" ${PEERS}
+ ${WEAVE} launch ${PEERS}
  exec /usr/bin/docker logs -f weave
 end script
 


### PR DESCRIPTION
Reverting this fix for DO - as it was causing massive CPU & memory spikes in AWS due to weaver taking up a lot of utilisation. The symptom is described over here https://github.com/weaveworks/weave/issues/417