### PR TITLE
fix chronos container hostname

### DIFF
--- a/roles/chronos/tasks/main.yml
+++ b/roles/chronos/tasks/main.yml
@@ -17,6 +17,7 @@
     name: chronos
     image: "{{ chronos_image }}"
     state: started
+    hostname: "{{ chronos_hostname }}"
     restart_policy: "{{ chronos_restart_policy }}"
     ports:
     - "{{ chronos_host_port }}:4400"


### PR DESCRIPTION
this fixes HA

chronos server registers itself with zookeeper using its hostname, which
is a random sha if not assigned.  As a result, redirects to the elected
master chronos server fail from both the gui and rest apis.