### PR TITLE
Drupal7 Json

### DIFF
--- a/examples/drupal-mysql/drupal7.json
+++ b/examples/drupal-mysql/drupal7.json
@@ -8,7 +8,7 @@
         "docker": {
           "image": "mysql:5.5",
           "network": "BRIDGE"
-        },
+        }
       },
       "env": {
         "SERVICE_NAME": "mysql",


### PR DESCRIPTION
Had to remove this comma as marathon was complaining about syntax error when trying to start the Drupal 7 example.