### PR TITLE
Added chronos_zk_url variable to ansible.extra_vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,7 +116,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               consul_join: consul_join,
               consul_retry_join: consul_retry_join,
               marathon_master_peers: marathon_master_peers,
-              marathon_zk_peers: marathon_zk_peers
+              marathon_zk_peers: marathon_zk_peers,
+              chronos_zk_url: chronos_zk_url
             }
           end
         end


### PR DESCRIPTION
There was an issue with running chronons on VM. It was because of we didn't pass chronos_zk_url into ansible variables.