### PR TITLE
Providing dynamic ip ranges different than 10.* for AWS based on vpc_cidr_block

### DIFF
--- a/bootstrap/aws/util.sh
+++ b/bootstrap/aws/util.sh
@@ -17,6 +17,10 @@ ansible_ssh_config() {
   pushd "${APOLLO_ROOT}/terraform/${APOLLO_PROVIDER}"
     export APOLLO_bastion_ip=$(terraform output bastion.ip)
 
+    # Virtual private cloud CIDR IP.
+    ip=$(terraform output vpc_cidr_block.ip)
+    export APOLLO_network_identifier=get_network_identifier ip
+
     cat <<EOF > ssh.config
   Host bastion $APOLLO_bastion_ip
     StrictHostKeyChecking  no
@@ -28,7 +32,7 @@ ansible_ssh_config() {
     PasswordAuthentication no
     UserKnownHostsFile     /dev/null
 
-  Host 10.*
+  Host $APOLLO_network_identifier.*
     StrictHostKeyChecking  no
     ServerAliveInterval    120
     TCPKeepAlive           yes
@@ -83,4 +87,3 @@ ovpn_client_config() {
       esac
     done
 }
-

--- a/bootstrap/common.sh
+++ b/bootstrap/common.sh
@@ -126,5 +126,8 @@ terraform_apply() {
   popd
 }
 
-
-
+# Helper function to get the fist octet of an IPv4 address.
+get_network_identifier() {
+  ip="$1"
+  echo $(echo $ip | tr "." " " | awk '{ print $1 }')
+}

--- a/bootstrap/tests/test.sh
+++ b/bootstrap/tests/test.sh
@@ -17,7 +17,7 @@ test() {
     echo "Pass. Function ${function}. Expected: ${expected}, Got: ${result}"
   else
     echo "${RED}Fail. Function ${function}. Expected: ${expected}, Got: ${result}${NC}"
-  fi	
+  fi
 }
 
 function="check_terraform_version"
@@ -38,4 +38,15 @@ export TESTSUITE_var4="property=val property=val property=val"
 function="get_apollo_variables"
 input="TESTSUITE_"
 expected="var4='property=val property=val property=val' var2='Drupal' var3='ip1 ip2 ip3' var1='Galicia'"
+test "${function}" "${expected}" "${input}"
+
+# Network identifier helper function tests.
+function="get_network_identifier"
+expected="10"
+input="10.0.0.0/16"
+test "${function}" "${expected}" "${input}"
+
+function="get_network_identifier"
+expected="172"
+input="172.31.1.0/24"
 test "${function}" "${expected}" "${input}"

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,3 +1,6 @@
+output "vpc_cidr_block.ip" {
+  value = "${aws_vpc.default.cidr_block}"
+}
 output "bastion.ip" {
   value = "${aws_eip.bastion.public_ip}"
 }


### PR DESCRIPTION
This PR removes the `10.` hardcoded value for AWS to provide a dynamic behaviour based on the value of the `aws_vpc.default.cidr_block` variable