### PR TITLE
Bump slave mem to 1532MB in vagrant.yml

### DIFF
--- a/vagrant.yml
+++ b/vagrant.yml
@@ -13,7 +13,7 @@ masters:
 slaves:
 # Memory and Cpus setting
   ##########################
-  mem: 1024
+  mem: 1536
   cpus: 2
   # Slave IPs - must be in the same private address range as the master instances
   # See http://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces


### PR DESCRIPTION
Currently Chronos fails to start under Marathon because when
slave goes up it has less then 512MB mem free

(at least on OSX Yosemite + VirtualBox 4.3.30 + vagrant 1.7.4)