### PR TITLE
Removing curl deployment in marathon spec.

### DIFF
--- a/tests/spec/marathon/marathon_spec.rb
+++ b/tests/spec/marathon/marathon_spec.rb
@@ -26,11 +26,6 @@ describe command("curl -s -XPOST 127.0.0.1:8080/v2/apps -d@spec/marathon/sample.
   its(:exit_status) { should eq 0 }
 end
 
-describe command("curl -s 127.0.0.1:8080/v2/deployments") do
-  its(:stdout) { should match '[]' }
-  its(:exit_status) { should eq 0 }
-end
-
 describe command("curl -s 127.0.0.1:8080/v2/apps/serverspecs-app") do
   its(:stdout) { should match '.*"id":"/serverspecs-app".*' }
   its(:stdout) { should match '.*"tasksRunning":1.*' }


### PR DESCRIPTION
This test is not true anymore as frameworks could be in deployment stage at this time