### PR TITLE
Set -resync flag for registrator reregistering all services

### DIFF
--- a/roles/registrator/tasks/main.yml
+++ b/roles/registrator/tasks/main.yml
@@ -16,7 +16,7 @@
     state: started
     restart_policy: always
     net: host
-    command: "-internal {{ registrator_uri }}"
+    command: "-internal -resync=120 {{ registrator_uri }}"
     volumes:
     - "/var/run/docker.sock:/tmp/docker.sock"
   environment: proxy_env


### PR DESCRIPTION
This allows registrator and the service registry to get back in sync if they fall out of sync