### PR TITLE
Dnsmasq container net to host.

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -29,6 +29,7 @@
     name: dnsmasq
     image: "andyshinn/dnsmasq"
     state: started
+    net: "host"
     privileged: true
     volumes:
     - "{{ dnsmasq_config_folder }}/:{{ dnsmasq_config_folder }}/"


### PR DESCRIPTION
Dnsmasq container needs set host to network for being able to resolve from inside a container.
This may be due to we are not able to set --cap-add=NET_ADMIN andyshinn/dnsmasq. via ansible until 2.0 get released