### PR TITLE
Using amis with docker 1.7.1

### DIFF
--- a/terraform/aws-public/variables.tf
+++ b/terraform/aws-public/variables.tf
@@ -84,15 +84,14 @@ variable "atlas_artifact_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-36a91536"
-    ap-southeast-1 = "ami-fe3c30ac"
-    ap-southeast-2 = "ami-8b6c2cb1"
-    eu-central-1 = "ami-8e313593"
-    eu-west-1 = "ami-e4b7e193"
-    sa-east-1 = "ami-dfc54cc2"
-    us-east-1 = "ami-7506a71e"
-    us-west-1 = "ami-5b51ad1f"
-    us-west-2 = "ami-83ece5b3"
+    ap-northeast-1 = "ami-364cfe36"
+    ap-southeast-1 = "ami-54b0bd06"
+    ap-southeast-2 = "ami-79145443"
+    eu-central-1 = "ami-fa7571e7"
+    eu-west-1 = "ami-d67c2ba1"
+    sa-east-1 = "ami-ed72fcf0"
+    us-east-1 = "ami-87d374ec"
+    us-west-1 = "ami-bb3fc3ff"
+    us-west-2 = "ami-5fafa16f"
   }
-}
 

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -98,13 +98,13 @@ variable "atlas_artifact_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-36a91536"
-    ap-southeast-1 = "ami-fe3c30ac"
-    ap-southeast-2 = "ami-8b6c2cb1"
-    eu-central-1 = "ami-8e313593"
-    eu-west-1 = "ami-e4b7e193"
-    sa-east-1 = "ami-dfc54cc2"
-    us-east-1 = "ami-7506a71e"
-    us-west-1 = "ami-5b51ad1f"
-    us-west-2 = "ami-83ece5b3"
+    ap-northeast-1 = "ami-364cfe36"
+    ap-southeast-1 = "ami-54b0bd06"
+    ap-southeast-2 = "ami-79145443"
+    eu-central-1 = "ami-fa7571e7"
+    eu-west-1 = "ami-d67c2ba1"
+    sa-east-1 = "ami-ed72fcf0"
+    us-east-1 = "ami-87d374ec"
+    us-west-1 = "ami-bb3fc3ff"
+    us-west-2 = "ami-5fafa16f"
   }


### PR DESCRIPTION
Using docker 1.7.1 while 1.8.0 is not released as 1.7.0 make dnsmasq on docker consistently fail