### PR TITLE
Libapparmor as a volume for mesos slave container.

### DIFF
--- a/roles/mesos/tasks/slave.yml
+++ b/roles/mesos/tasks/slave.yml
@@ -26,6 +26,7 @@
     - "/lib/libpthread.so.0:/lib/libpthread.so.0:ro"
     - "/usr/bin/docker:/usr/bin/docker:ro"
     - "/var/run/docker.sock:/var/run/docker.sock"
+    - "/usr/lib/x86_64-linux-gnu/libapparmor.so.1.1.0:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"
     ports:
     - "{{ mesos_slave_port }}:{{ mesos_slave_port }}"
     net: "host"


### PR DESCRIPTION
Docker is now dynamically linked. Dependencies needs to be made available
Tested with docker 1.8.1 so Waiting for https://github.com/Capgemini/Apollo/pull/449/files