### PR TITLE
Udacity secure elb

### DIFF
--- a/packer/scripts/ubuntu/install_docker.sh
+++ b/packer/scripts/ubuntu/install_docker.sh
@@ -20,7 +20,7 @@ docker pull mesosphere/mesos:${MESOS_VERSION}
 docker pull mesosphere/mesos-master:${MESOS_VERSION}
 docker pull mesosphere/mesos-slave:${MESOS_VERSION}
 docker pull gliderlabs/registrator:master
-docker pull asteris/haproxy-consul:latest
+docker pull udacity/haproxy-consul:latest
 docker pull weaveworks/weave:${WEAVE_VERSION}
 docker pull weaveworks/scope:latest
 docker pull mesosphere/marathon:${MARATHON_VERSION}

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for haproxy
-haproxy_image: asteris/haproxy-consul
+haproxy_image: udacity/haproxy-consul
 haproxy_image_tag: latest
 
 # Set the domain that haproxy uses to match URLs to internal apps.

--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -21,6 +21,9 @@ frontend haproxy_status
 frontend www
     bind *:80
 
+    acl is_http hdr(X-Forwarded-Proto) http
+    redirect scheme https code 301 if is_http
+
     # Generated automatically by consul-template
 {{range $tag, $services := services | byTag}}{{ if eq $tag "public" }}{{range $services}}
     acl host_{{.Name}} hdr(host) -i {{.Name}}.{{env "HAPROXY_DOMAIN"}}

--- a/roles/haproxy/files/haproxy.tmpl
+++ b/roles/haproxy/files/haproxy.tmpl
@@ -22,13 +22,17 @@ frontend www
     bind *:80
 
     # Generated automatically by consul-template
-{{range services}}
+{{range $tag, $services := services | byTag}}{{ if eq $tag "public" }}{{range $services}}
     acl host_{{.Name}} hdr(host) -i {{.Name}}.{{env "HAPROXY_DOMAIN"}}
     use_backend {{.Name}}_backend if host_{{.Name}}
-{{end}}
+{{end}}{{end}}{{end}}
 
-{{range services}}
+{{range $tag, $services := services | byTag}}{{ if eq $tag "public" }}{{range $services}}
 backend {{.Name}}_backend
 {{range service .Name}}
    server {{.Node}} {{.Address}}:{{.Port}}{{end}}
-{{end}}
+{{end}}{{end}}{{end}}
+
+backend consul_backend
+{{range service "consul"}}
+   server {{.Node}} {{.Address}}:{{.Port}}{{end}}

--- a/terraform/aws/mesos-slaves.tf
+++ b/terraform/aws/mesos-slaves.tf
@@ -48,6 +48,13 @@ resource "aws_elb" "app" {
     ssl_certificate_id = "${var.ssl_certificate_arn}"
   }
 
+  listener {
+    instance_port = 80
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/terraform/aws/mesos-slaves.tf
+++ b/terraform/aws/mesos-slaves.tf
@@ -43,8 +43,9 @@ resource "aws_elb" "app" {
   listener {
     instance_port = 80
     instance_protocol = "http"
-    lb_port = 80
-    lb_protocol = "http"
+    lb_port = 443
+    lb_protocol = "https"
+    ssl_certificate_id = "${var.ssl_certificate_arn}"
   }
 
   health_check {

--- a/terraform/aws/security_groups.tf
+++ b/terraform/aws/security_groups.tf
@@ -75,6 +75,13 @@ resource "aws_security_group" "web" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   tags {
     Name = "web-apollo-mesos"
   }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -13,6 +13,11 @@ variable "key_name" {
   default = "Apollo"
 }
 
+variable "ssl_certificate_arn" {
+  description = "arn for ssl certificate"
+  default = ""
+}
+
 variable "key_file" {
   description = "The ssh public key for using with the cloud provider."
   default = ""


### PR DESCRIPTION
This secures the aws load balancer, only allowing TLS traffic, terminating at the load balancers.
Only 'public' -tagged services in consul will be exported; that means marathon, mesos etc aren't exposed to the world.
We are using udacity's version of haproxy-consul because we need to use v0.10.0 of consul-template
https://github.com/udacity/haproxy-consul