### PR TITLE
Udacity add weave scope disable flag

### DIFF
--- a/roles/weave/defaults/main.yml
+++ b/roles/weave/defaults/main.yml
@@ -27,3 +27,4 @@ weave_launch_peers: "
 weave_docker_opts: "--bridge=weave --fixed-cidr={{ weave_docker_subnet }} --dns 172.17.42.1 --dns 8.8.8.8 --dns-search service.{{ consul_domain }}"
 weave_scope_url: https://github.com/weaveworks/scope/releases/download/latest_release/scope
 weave_scope_dest: /usr/local/bin/scope
+weave_scope_enabled: True

--- a/roles/weave/tasks/main.yml
+++ b/roles/weave/tasks/main.yml
@@ -62,7 +62,7 @@
     mode: 0755
     validate_certs: no
   environment: proxy_env
-  when: weave_enable_scope
+  when: weave_scope_enabled
   tags:
     - weave
 
@@ -72,6 +72,6 @@
     dest: "/etc/init/weavescope.conf"
     mode: 0755
   sudo: yes
-  when: weave_enable_scope
+  when: weave_scope_enabled
   tags:
     - weave

--- a/roles/weave/tasks/main.yml
+++ b/roles/weave/tasks/main.yml
@@ -62,6 +62,7 @@
     mode: 0755
     validate_certs: no
   environment: proxy_env
+  when: weave_enable_scope
   tags:
     - weave
 
@@ -71,5 +72,6 @@
     dest: "/etc/init/weavescope.conf"
     mode: 0755
   sudo: yes
+  when: weave_enable_scope
   tags:
     - weave


### PR DESCRIPTION
weave scope is a massive resource-hog, often taking up constant 20%+ cpu on slaves and masters.
As more containers are launched on the cluster, the scope UI doesn't scale well and the utility of weave scope doesn't justify its cost.  We needed a flag to turn it off.