### PR TITLE
Udacity rebuild container flags

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -8,6 +8,8 @@ haproxy_image_tag: latest
 #    app1.example.com, app2.example.com, etc.  set this to 'example.com'
 haproxy_domain: example.com
 
+haproxy_rebuild_container: False
+
 consul_template_dir: /mnt/consul-template.d
 consul_template_loglevel: debug
 consul_backend: consul.service.consul:8500

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -31,6 +31,13 @@
   tags:
     - haproxy
 
+- name: destroy old haproxy container
+  when: haproxy_rebuild_container
+  docker:
+    name: haproxy
+    image: "{{ haproxy_image }}"
+    state: absent
+
 - name: run haproxy container
   docker:
     name: haproxy

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -12,6 +12,7 @@ marathon_java_settings: '-Xmx512m -Xms512m -XX:+HeapDumpOnOutOfMemoryError'
 marathon_artifact_store: 'file:///store'
 marathon_artifact_store_dir: '/etc/marathon/store'
 marathon_server_zk_group: marathon_servers
+marathon_rebuild_container: False
 marathon_image: "mesosphere/marathon:v{{ marathon_version }}"
 marathon_master_peers: "zk://{{ zookeeper_peers_nodes }}/mesos"
 marathon_zk_peers: "zk://{{ zookeeper_peers_nodes }}/marathon"

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: destroy old marathon container
   when: marathon_rebuild_container
   docker:
-    name: chronos
+    name: marathon
     image: "{{ marathon_image }}"
     state: absent
 

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -21,6 +21,13 @@
   tags:
     - marathon
 
+- name: destroy old marathon container
+  when: marathon_rebuild_container
+  docker:
+    name: chronos
+    image: "{{ marathon_image }}"
+    state: absent
+
 - name: run marathon container
   when: marathon_enabled | bool
   docker:

--- a/roles/registrator/defaults/main.yml
+++ b/roles/registrator/defaults/main.yml
@@ -2,4 +2,5 @@
 # defaults file for registrator
 registrator_image: "gliderlabs/registrator:master"
 registrator_uri: "consul://{{ ansible_default_ipv4.address }}:8500"
+registrator_rebuild_container: False
 

--- a/roles/registrator/tasks/main.yml
+++ b/roles/registrator/tasks/main.yml
@@ -8,6 +8,13 @@
   tags:
     - registrator
 
+- name: destroy old marathon container
+  when: registrator_rebuild_container
+  docker:
+    name: registrator
+    image: "{{ registrator_image }}"
+    state: absent
+
 # tasks file for docker registrator
 - name: run registrator container
   docker:


### PR DESCRIPTION
allows the operator to selectively taint running containers and just run the idempotent bootstrap/apollo-launch.sh, (e.g. changing config files for haproxy, etc)