### PR TITLE
Weave upgrade 1.2.0, fastadapath and respecting docker0 as default bridge

### DIFF
--- a/packer/scripts/common/install_weave.sh
+++ b/packer/scripts/common/install_weave.sh
@@ -3,6 +3,6 @@ set -eux
 set -o pipefail
 
 sudo wget -O /usr/local/bin/weave \
-    https://github.com/weaveworks/weave/releases/download/${WEAVE_VERSION}/weave
+    https://github.com/weaveworks/weave/releases/download/v${WEAVE_VERSION}/weave
 sudo chmod a+x /usr/local/bin/weave
 

--- a/packer/ubuntu-14.04_amd64-amis.json
+++ b/packer/ubuntu-14.04_amd64-amis.json
@@ -5,7 +5,7 @@
     "mesos_version": "0.23.0-1.0.ubuntu1404",
     "marathon_version": "v0.10.1",
     "consul_version": "0.5.2",
-    "weave_version": "v1.1.0",
+    "weave_version": "1.2.0",
     "docker_version": "1.8.2-0~trusty",
     "version": "{{env `APOLLO_VERSION`}}",
     "aws_region": "{{env `AWS_REGION`}}",

--- a/packer/ubuntu-14.04_amd64-droplet.json
+++ b/packer/ubuntu-14.04_amd64-droplet.json
@@ -7,7 +7,7 @@
     "mesos_version": "0.23.0-1.0.ubuntu1404",
     "marathon_version": "v0.10.1",
     "consul_version": "0.5.2",
-    "weave_version": "v1.1.0",
+    "weave_version": "1.2.0",
     "docker_version": "1.8.2-0~trusty",
     "version": "{{env `APOLLO_VERSION`}}"
   },

--- a/packer/ubuntu-14.04_amd64-google.json
+++ b/packer/ubuntu-14.04_amd64-google.json
@@ -7,7 +7,7 @@
     "mesos_version": "0.23.0-1.0.ubuntu1404",
     "marathon_version": "v0.10.1",
     "consul_version": "0.5.2",
-    "weave_version": "v1.1.0",
+    "weave_version": "1.2.0",
     "docker_version": "1.8.2-0~trusty",
     "version": "{{env `APOLLO_VERSION`}}"
   },

--- a/packer/ubuntu-14.04_amd64.json
+++ b/packer/ubuntu-14.04_amd64.json
@@ -11,7 +11,7 @@
     "mesos_version": "0.23.0-1.0.ubuntu1404",
     "marathon_version": "v0.10.1",
     "consul_version": "0.5.2",
-    "weave_version": "v1.1.0",
+    "weave_version": "1.2.0",
     "docker_version": "1.8.2-0~trusty",
     "access_token": "{{env `ATLAS_TOKEN`}}",
     "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.3-server-amd64.iso",

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -15,7 +15,7 @@
     dest: /etc/default/docker
     state: present
     regexp: ^DOCKER_OPTS=.*--graph.*
-    line: 'DOCKER_OPTS=\"$DOCKER_OPTS --graph={{ docker_graph_dir }}\"'
+    line: 'DOCKER_OPTS=\"$DOCKER_OPTS --graph={{ docker_graph_dir }} --dns 172.17.42.1 --dns 8.8.8.8 --dns-search service.{{ consul_domain }} \"'
   notify:
     - restart docker
 

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -4,7 +4,7 @@ marathon_consul_dir: /etc/consul.d
 marathon_enabled: true
 marathon_version: '0.10.1'
 marathon_restart_policy: 'always'
-marathon_net: 'bridge'
+marathon_net: 'host'
 marathon_hostname: "{{ ansible_ssh_host }}"
 marathon_port: '8080'
 marathon_container_memory_limit: '512MB'

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -40,7 +40,6 @@
     command: "{{ marathon_command }}"
     volumes:
     - "{{ marathon_artifact_store_dir }}:/store"
-    - "/var/run/docker.sock:/tmp/docker.sock"
     memory_limit: "{{ marathon_container_memory_limit }}"
     env:
       JAVA_OPTS: "{{ marathon_java_settings }}"

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -5,6 +5,7 @@ mesos_executor_registration_timeout: 10mins
 mesos_cluster_name: "Cluster01"
 mesos_ip: "{{ ansible_default_ipv4.address }}"
 mesos_hostname: "{{ ansible_ssh_host }}"
+mesos_docker_socket: "/var/run/weave/weave.sock"
 
 # Defaults file for mesos-salve
 mesos_slave_port: 5051

--- a/roles/mesos/tasks/slave.yml
+++ b/roles/mesos/tasks/slave.yml
@@ -25,8 +25,8 @@
     - "/sys:/sys"
     - "/lib/libpthread.so.0:/lib/libpthread.so.0:ro"
     - "/usr/bin/docker:/usr/bin/docker:ro"
-    - "/var/run/docker.sock:/var/run/docker.sock"
     - "/usr/lib/x86_64-linux-gnu/libapparmor.so.1.1.0:/usr/lib/x86_64-linux-gnu/libapparmor.so.1"
+    - "{{ mesos_docker_socket }}:/var/run/docker.sock"
     ports:
     - "{{ mesos_slave_port }}:{{ mesos_slave_port }}"
     net: "host"

--- a/roles/registrator/defaults/main.yml
+++ b/roles/registrator/defaults/main.yml
@@ -3,4 +3,4 @@
 registrator_image: "gliderlabs/registrator:master"
 registrator_uri: "consul://{{ ansible_default_ipv4.address }}:8500"
 registrator_rebuild_container: False
-
+registrator_docker_socket: "/var/run/weave/weave.sock"

--- a/roles/registrator/tasks/main.yml
+++ b/roles/registrator/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: wait for weave socket to be ready.
+  wait_for:
+    port: 6783
+    delay: 10
+
 - name: destroy old marathon container
   when: registrator_rebuild_container
   docker:
@@ -14,9 +20,9 @@
     state: started
     restart_policy: always
     net: host
-    command: "-internal -resync=120 {{ registrator_uri }}"
+    command: "-internal -resync=10 {{ registrator_uri }}"
     volumes:
-    - "/var/run/docker.sock:/tmp/docker.sock"
+    - "{{ registrator_docker_socket }}:/tmp/docker.sock"
   environment: proxy_env
   tags:
     - registrator

--- a/roles/weave/defaults/main.yml
+++ b/roles/weave/defaults/main.yml
@@ -1,20 +1,7 @@
 ---
+
 # defaults file for weave
-weave_bridge: "
-    {%- for host in groups[weave_server_group] -%}
-      {%- if host == 'default' or host == inventory_hostname or host == ansible_fqdn or host in ansible_all_ipv4_addresses -%}
-        10.2.0.{{ loop.index }}/16
-      {%- endif -%}
-    {%- endfor -%}
-"
 weave_server_group: weave_servers
-weave_docker_subnet: "
-    {%- for host in groups[weave_server_group] -%}
-      {%- if host == 'default' or host == inventory_hostname or host == ansible_fqdn or host in ansible_all_ipv4_addresses -%}
-        10.2.{{ loop.index }}.0/24
-      {%- endif -%}
-    {%- endfor -%}
-"
 weave_launch_peers: "
   {%- set weave_peers = [] -%}
   {%- for host in groups[weave_server_group] -%}
@@ -24,7 +11,7 @@ weave_launch_peers: "
   {%- endfor -%}
   {{ weave_peers|join(' ') }}
 "
-weave_docker_opts: "--bridge=weave --fixed-cidr={{ weave_docker_subnet }} --dns 172.17.42.1 --dns 8.8.8.8 --dns-search service.{{ consul_domain }}"
+
 weave_scope_url: https://github.com/weaveworks/scope/releases/download/latest_release/scope
 weave_scope_dest: /usr/local/bin/scope
 weave_scope_enabled: True

--- a/roles/weave/tasks/main.yml
+++ b/roles/weave/tasks/main.yml
@@ -1,37 +1,4 @@
 ---
-# tasks file for weave
-- name: include all interfaces.d
-  sudo: yes
-  lineinfile:
-    dest: /etc/network/interfaces
-    state: present
-    line: 'source /etc/network/interfaces.d/*.cfg'
-  tags:
-    - weave
-
-# Start docker as it is a requirement for weave create-bridge.
-- name: Start up docker
-  service:
-    name: docker
-    state: started
-  tags:
-    - weave
-
-- name: configure weave interface
-  sudo: yes
-  template:
-    src: interfaces.j2
-    dest: /etc/network/interfaces.d/weave.cfg
-    owner: root
-    group: root
-    mode: 0644
-  tags:
-    - weave
-
-# Create weave bridge.
-- name: bring up weave bridge
-  command: ifup weave
-  sudo: yes
 
 - name: upload weave template service
   template:
@@ -42,18 +9,12 @@
   tags:
     - weave
 
-# Restart docker with weave bridge available and triggers weave service.
-- name: configure weave bridge for docker
+- name: ensure weave service is running.
   sudo: yes
-  lineinfile:
-    dest: /etc/default/docker
-    state: present
-    regexp: ^DOCKER_OPTS=.*--bridge=weave.*
-    line: 'DOCKER_OPTS=\"$DOCKER_OPTS {{ weave_docker_opts }}\"'
-  notify:
-    - restart docker
-  tags:
-    - weave
+  service:
+    name: weave
+    state: started
+    enabled: yes
 
 - name: download weave scope
   get_url:

--- a/roles/weave/templates/interfaces.j2
+++ b/roles/weave/templates/interfaces.j2
@@ -1,6 +1,0 @@
-auto weave
-iface weave inet manual
-  pre-up /usr/local/bin/weave create-bridge
-  post-up ip addr add dev weave {{ weave_bridge }}
-  pre-down ifconfig weave down
-  post-down brctl delbr weave

--- a/roles/weave/templates/weave.conf.j2
+++ b/roles/weave/templates/weave.conf.j2
@@ -5,12 +5,15 @@ stop on stopping docker
 
 env PEERS="{{ weave_launch_peers }}"
 env WEAVE='/usr/local/bin/weave'
+env WEAVE_VERSION='git-6a238818daf2'
 
 pre-start exec ${WEAVE} stop
 
 script
  [ -e /etc/default/weave ] && . /etc/default/weave
- ${WEAVE} launch ${PEERS}
+ ${WEAVE} launch-router --no-dns ${PEERS}
+ ${WEAVE} launch-proxy --without-dns --rewrite-inspect
+ ${WEAVE} expose
  exec /usr/bin/docker logs -f weave
 end script
 

--- a/site.yml
+++ b/site.yml
@@ -28,8 +28,8 @@
     - docker
     - weave
     - dnsmasq
-    - registrator
     - cadvisor
+    - registrator
 
 - hosts: mesos_masters
   roles:

--- a/terraform/aws-public/variables.tf
+++ b/terraform/aws-public/variables.tf
@@ -84,14 +84,14 @@ variable "atlas_artifact_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-ea0e9aea"
-    ap-southeast-1 = "ami-00243152"
-    ap-southeast-2 = "ami-07dc933d"
-    eu-central-1 = "ami-62fcfc7f"
-    eu-west-1 = "ami-23bb9954"
-    sa-east-1 = "ami-bd74e1a0"
-    us-east-1 = "ami-b13145d4"
-    us-west-1 = "ami-95eb2ed1"
-    us-west-2 = "ami-75584745"
+    ap-northeast-1 = "ami-75dcf81b"
+    ap-southeast-1 = "ami-7324e310"
+    ap-southeast-2 = "ami-a60c52c5"
+    eu-central-1 = "ami-950b18f9"
+    eu-west-1 = "ami-f603dd85"
+    sa-east-1 = "ami-da962db6"
+    us-east-1 = "ami-be106dd4"
+    us-west-1 = "ami-7b046b1b"
+    us-west-2 = "ami-00657261"
   }
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -98,14 +98,14 @@ variable "atlas_artifact_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-ea0e9aea"
-    ap-southeast-1 = "ami-00243152"
-    ap-southeast-2 = "ami-07dc933d"
-    eu-central-1 = "ami-62fcfc7f"
-    eu-west-1 = "ami-23bb9954"
-    sa-east-1 = "ami-bd74e1a0"
-    us-east-1 = "ami-b13145d4"
-    us-west-1 = "ami-95eb2ed1"
-    us-west-2 = "ami-75584745"
+    ap-northeast-1 = "ami-75dcf81b"
+    ap-southeast-1 = "ami-7324e310"
+    ap-southeast-2 = "ami-a60c52c5"
+    eu-central-1 = "ami-950b18f9"
+    eu-west-1 = "ami-f603dd85"
+    sa-east-1 = "ami-da962db6"
+    us-east-1 = "ami-be106dd4"
+    us-west-1 = "ami-7b046b1b"
+    us-west-2 = "ami-00657261"
   }
 }

--- a/tests/spec/weave/weave_spec.rb
+++ b/tests/spec/weave/weave_spec.rb
@@ -8,17 +8,6 @@ describe bridge('weave') do
   it { should exist }
 end
 
-describe file('/etc/network/interfaces') do
-  it            { should be_file }
-  its(:content) { should match /source \/etc\/network\/interfaces.d\/\*\.cfg/ }
-end
-
-describe file('/etc/network/interfaces.d/weave.cfg') do
-  it            { should be_file }
-  its(:content) { should match /iface weave inet manual/ }
-  it { should be_mode 644 }
-end
-
 describe docker_container('weave') do
   it { should be_running }
 end
@@ -37,7 +26,3 @@ describe file('/etc/init/weavescope.conf') do
   it { should be_mode 755 }
 end
 
-describe file('/etc/default/docker') do
-  it            { should be_file }
-  its(:content) { should match /--bridge=weave/ }
-end


### PR DESCRIPTION
This provides a pretty basic weave 1.2.0 setup so using fastdatapath and respecting the docker0 bridge as the default docker bridge.

**Known issues:**
When running a new service on the cluster Registrator is storing in the first place the docker ip instead of the weave one. If Registrator get restarted it stores the weave ip.
This hopefully will be fixed once this gets it https://github.com/weaveworks/weave/issues/1549
So we can rebuild the images then.

Once docker 1.9 gets released weave/registrator/consul ecosystem will be broken unless this gets support https://github.com/weaveworks/weave/issues/1601

**TODOS:**
To provide Application/environment isolation via weave subnets.

**Future roadmap:**
To investigate and implement a more flexible/pluggable networking system for Apollo once Docker 1.9 with libnetwork support get released https://github.com/docker/libnetwork and mesos net modules becomes stable.
See https://github.com/docker/libnetwork/blob/master/docs/overlay.md
See https://github.com/projectcalico/calico-docker/blob/master/docs/getting-started/libnetwork/Demonstration.md
Once we move to mesos 0.25.0:
See http://mesos.apache.org/documentation/latest/networking-for-mesos-managed-containers/
See https://github.com/mesosphere/net-modules