### PR TITLE
DOCKER_HOST to weave socket when running ansible.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -22,3 +22,4 @@ proxy_env:
   HTTP_PROXY: ''
   HTTPS_PROXY: ''
 http_proxy: ''
+docker_host: 'unix:///var/run/weave/weave.sock'

--- a/roles/cadvisor/meta/main.yml
+++ b/roles/cadvisor/meta/main.yml
@@ -121,7 +121,7 @@ galaxy_info:
   - system
   #- web
 dependencies:
-  # - role: consul
+  - role: handlers
   # - role: registrator
   # - role: zookeeper
   # List your role dependencies here, one per line. Only

--- a/roles/handlers/handlers/main.yml
+++ b/roles/handlers/handlers/main.yml
@@ -15,3 +15,10 @@
    name: docker
    state: restarted
   sudo: yes
+  notify:
+  - wait for weave to listen
+
+- name: wait for weave to listen
+  wait_for:
+    port: 6783
+    delay: 10

--- a/roles/weave/tasks/main.yml
+++ b/roles/weave/tasks/main.yml
@@ -16,6 +16,11 @@
     state: started
     enabled: yes
 
+- name: wait for weave socket to be ready.
+  wait_for:
+    port: 6783
+    delay: 10
+
 - name: download weave scope
   get_url:
     url: "{{ weave_scope_url }}"

--- a/site.yml
+++ b/site.yml
@@ -27,28 +27,41 @@
     - consul
     - docker
     - weave
+
+- hosts: all:!role=bastion
+  roles:
+    - registrator
     - dnsmasq
     - cadvisor
-    - registrator
+  environment:
+    DOCKER_HOST: "{{ docker_host }}"
 
 - hosts: mesos_masters
   roles:
     - zookeeper
     - { role: mesos, mesos_install_mode: "master" }
     - marathon
+  environment:
+    DOCKER_HOST: "{{ docker_host }}"
 
 - hosts: mesos_slaves
   roles:
     - { role: mesos, mesos_install_mode: "slave" }
+  environment:
+    DOCKER_HOST: "{{ docker_host }}"
 
 - hosts: load_balancers
   roles:
     - { role: haproxy, tags: ["haproxy"] }
+  environment:
+    DOCKER_HOST: "{{ docker_host }}"
 
 # Installing DCOS frameworks from one master.
 - hosts: mesos_masters
   roles:
     - frameworks
+  environment:
+    DOCKER_HOST: "{{ docker_host }}"
 
 - include: tests/test.yml
   vars_files:


### PR DESCRIPTION
This set the DOCKER_HOST env variable to be the weave socket at ansible runtime level so containers run by ansible docker module go through weave proxy.
The other possibility is to handle it at the task level an just set the socket as another variable same we are doing for the net, image, state or volumes. Personally I'd be in favour of the second approach so opening this for discussion.  