### PR TITLE
kernel 3.19 images and overlay fs.

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -15,7 +15,7 @@
     dest: /etc/default/docker
     state: present
     regexp: ^DOCKER_OPTS=.*--graph.*
-    line: 'DOCKER_OPTS=\"$DOCKER_OPTS --graph={{ docker_graph_dir }} --dns 172.17.0.1 --dns 8.8.8.8 --dns-search service.{{ consul_domain }} \"'
+    line: 'DOCKER_OPTS=\"$DOCKER_OPTS --storage-driver=overlay --graph={{ docker_graph_dir }} --dns 172.17.0.1 --dns 8.8.8.8 --dns-search service.{{ consul_domain }} \"'
   notify:
     - restart docker
 

--- a/terraform/aws-public/variables.tf
+++ b/terraform/aws-public/variables.tf
@@ -84,14 +84,14 @@ variable "atlas_artifact_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-113d1a7f"
-    ap-southeast-1 = "ami-7c53941f"
-    ap-southeast-2 = "ami-4a5e0029"
-    eu-central-1   = "ami-372b385b"
-    eu-west-1      = "ami-a1b26bd2"
-    sa-east-1      = "ami-be58e3d2"
-    us-east-1      = "ami-6e562a04"
-    us-west-1      = "ami-b25a35d2"
-    us-west-2      = "ami-9ef6e1ff"
+    ap-northeast-1 = "ami-a53c1dcb"
+    ap-southeast-1 = "ami-8ce82eef"
+    ap-southeast-2 = "ami-31df8152"
+    eu-central-1   = "ami-9ebcaff2"
+    eu-west-1      = "ami-225e8651"
+    sa-east-1      = "ami-f3e05a9f"
+    us-east-1      = "ami-43eb9229"
+    us-west-1      = "ami-1f29477f"
+    us-west-2      = "ami-bd8492dc"
   }
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -103,14 +103,14 @@ variable "docker_version" {
 /* Remember to update the list every time when you build a new artifact on atlas */
 variable "amis" {
   default = {
-    ap-northeast-1 = "ami-113d1a7f"
-    ap-southeast-1 = "ami-7c53941f"
-    ap-southeast-2 = "ami-4a5e0029"
-    eu-central-1   = "ami-372b385b"
-    eu-west-1      = "ami-a1b26bd2"
-    sa-east-1      = "ami-be58e3d2"
-    us-east-1      = "ami-6e562a04"
-    us-west-1      = "ami-b25a35d2"
-    us-west-2      = "ami-9ef6e1ff"
+    ap-northeast-1 = "ami-a53c1dcb"
+    ap-southeast-1 = "ami-8ce82eef"
+    ap-southeast-2 = "ami-31df8152"
+    eu-central-1   = "ami-9ebcaff2"
+    eu-west-1      = "ami-225e8651"
+    sa-east-1      = "ami-f3e05a9f"
+    us-east-1      = "ami-43eb9229"
+    us-west-1      = "ami-1f29477f"
+    us-west-2      = "ami-bd8492dc"
   }
 }


### PR DESCRIPTION
Setting the base images with kernel 3.19
Setting overlay as fs.
Paving the way for overlay network.
