### PR TITLE
attach ebs to root partition.

### DIFF
--- a/terraform/aws-public/mesos-slaves.tf
+++ b/terraform/aws-public/mesos-slaves.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "mesos-slave" {
     role = "mesos_slaves"
   }
   ebs_block_device {
-    device_name           = "/dev/sdb"
+    device_name           = "/dev/sda1"
     volume_size           = "${var.slave_block_device.volume_size}"
     delete_on_termination = true
   }

--- a/terraform/aws/mesos-slaves.tf
+++ b/terraform/aws/mesos-slaves.tf
@@ -28,7 +28,7 @@ resource "aws_instance" "mesos-slave" {
     role = "mesos_slaves"
   }
   ebs_block_device {
-    device_name           = "/dev/sdb"
+    device_name           = "/dev/sda1"
     volume_size           = "${var.slave_block_device.volume_size}"
     delete_on_termination = true
   }


### PR DESCRIPTION
At the moment we are attaching the ebs but then is not being mounted so it's not used.
This merge the ebs with the default ami mount root partition where we need more space as only the docker images makes it run out of space.