### PR TITLE
Add support for docker private registry

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,5 +1,22 @@
 ---
 # tasks file for docker
+- name: ensure docker config dir exists
+  sudo: yes
+  file:
+    path: /root/.docker
+    state: directory
+  tags:
+    - docker
+
+- name: setup private docker registry credentials
+  sudo: yes
+  when: private_docker_registry|bool
+  template:
+    src: config.json.j2
+    dest: /root/.docker/config.json
+  tags:
+    - docker
+
 - name: deploy docker service
   sudo: yes
   sudo_user: root

--- a/roles/docker/templates/config.json.j2
+++ b/roles/docker/templates/config.json.j2
@@ -1,0 +1,8 @@
+{
+    "auths": {
+        "{{ docker_registry_url }}": {
+            "auth": "{{ docker_registry_auth }}",
+            "email": "{{ docker_registry_email }}"
+        }
+    }
+}

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for marathon
 marathon_consul_dir: /etc/consul.d
 marathon_enabled: true
-marathon_version: '0.15.1'
+marathon_version: '0.15.2'
 marathon_restart_policy: 'always'
 marathon_net: 'host'
 marathon_hostname: "{{ ansible_ssh_host }}"

--- a/roles/mesos/templates/mesos-slave.service.j2
+++ b/roles/mesos/templates/mesos-slave.service.j2
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/docker run --rm --name mesos_slave \
 -v /sys:/sys \
 -v /proc:/host/proc:ro \
 -v /lib/libgcrypt.so:/lib/libgcrypt.so:ro \
+-v /lib/libgcrypt.so:/lib/libgcrypt.so.20:ro \
 -v /lib/libsystemd.so.0:/lib/libsystemd.so.0:ro \
 -v /lib/libpthread.so.0:/lib/libpthread.so.0:ro \
 -v /lib64/libdevmapper.so.1.02:/lib/libdevmapper.so.1.02:ro \


### PR DESCRIPTION
This adds simple support for private docker registry if you set some variables (which can be set as external). Comes with a couple of caveats - 

- no support for multiple registries
- not ideal handling of generating the private registry credentials (via just env vars)

I think we can support this better in the future if we have better support overall for securing the platform and do the bootstrap as a multi-step process (e.g. generate security info and then bootstrap the cluster with it in place) 