### PR TITLE
fixed ssh name for the bastion host

### DIFF
--- a/bootstrap/aws/private-cloud/util.sh
+++ b/bootstrap/aws/private-cloud/util.sh
@@ -36,11 +36,11 @@ ansible_ssh_config() {
     StrictHostKeyChecking  no
     ServerAliveInterval    120
     TCPKeepAlive           yes
-    ProxyCommand           ssh -q -A -F $(pwd)/ssh.config core@$APOLLO_bastion_ip nc %h %p
+    ProxyCommand           ssh -q -A -F $(pwd)/ssh.config ubuntu@$APOLLO_bastion_ip nc %h %p
     ControlMaster          auto
     ControlPath            ~/.ssh/mux-%r@%h:%p
     ControlPersist         30m
-    User                   core
+    User                   ubuntu
     IdentityFile           $TF_VAR_private_key_file
     UserKnownHostsFile     /dev/null
 EOF


### PR DESCRIPTION
replaced user name from core to ubuntu in order to successfully ssh to the bastion host in aws private