### PR TITLE
Proper fix for the apollo-down bug.

### DIFF
--- a/bootstrap/aws/private-cloud/util.sh
+++ b/bootstrap/aws/private-cloud/util.sh
@@ -51,9 +51,7 @@ apollo_down() {
   pushd "${APOLLO_ROOT}/terraform/${APOLLO_PROVIDER}"
     terraform destroy -var "access_key=${TF_VAR_access_key}" \
       -var "key_file=${TF_VAR_key_file}" \
-      -var "region=${TF_VAR_region}" 
-    > ${TF_VAR_etcd_discovery_url_file:-etcd_discovery_url.txt}
-
+      -var "region=${TF_VAR_region}"
   popd
 }
 

--- a/bootstrap/aws/public-cloud/util.sh
+++ b/bootstrap/aws/public-cloud/util.sh
@@ -23,8 +23,6 @@ apollo_down() {
     terraform destroy -var "access_key=${TF_VAR_access_key}" \
       -var "key_file=${TF_VAR_key_file}" \
       -var "region=${TF_VAR_region}"
-    > ${TF_VAR_etcd_discovery_url_file:-etcd_discovery_url.txt}
-
   popd
 }
 


### PR DESCRIPTION
The previous bug fix was not properly checked in.  This should fix the output of ```terraform destroy``` from being redirected to the ```etcd_discovery_url.txt``` file.