### PR TITLE
Update aws documentation

### DIFF
--- a/docs/getting-started-guides/aws-public.md
+++ b/docs/getting-started-guides/aws-public.md
@@ -39,11 +39,12 @@ For a full list of default config options for AWS see `bootstrap/aws-public/conf
 As a minimum you will need to set these environment variables -
 
 ```
-APOLLO_PROVIDER=aws-public
+APOLLO_PROVIDER=aws/public-cloud
 TF_VAR_access_key
 TF_VAR_secret_key
 TF_VAR_key_name="deployer"
 TF_VAR_key_file='~/.ssh/id_rsa_aws.pub'
+TF_VAR_public_key_file='~/.ssh/id_rsa_aws.pub'
 ```
 
 #### Turn up the cluster

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -40,12 +40,13 @@ For a full list of default config options for AWS see `bootstrap/aws/config-defa
 As a minimum you will need to set these environment variables -
 
 ```
-APOLLO_PROVIDER=aws
+APOLLO_PROVIDER=aws/private-cloud
 TF_VAR_user
 TF_VAR_access_key
 TF_VAR_secret_key
 TF_VAR_key_name="deployer"
 TF_VAR_key_file='~/.ssh/id_rsa_aws.pub'
+TF_VAR_public_key_file='~/.ssh/id_rsa_aws.pub'
 TF_VAR_private_key_file='~/.ssh/id_rsa_aws.pem'
 ```
 


### PR DESCRIPTION
One thing to note is that there are references to both ```${var.public_key_file}``` (in ```main.tf```) and as well as ```TF_VAR_key_file``` (in ```util.sh```), so both ```TF_VAR_public_key_file``` and ```TF_VAR_key_file``` need to be defined.

It might be better to merge these variables into a single one.