### PR TITLE
Fixes ansible error accessing "ansible_default_ipv4" on Mac OS X

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,9 @@
 
 - include: playbooks/coreos-bootstrap.yml
 
+- hosts: all
+  tasks: []
+
 - hosts: all:!role=bastion
   roles:
     - docker


### PR DESCRIPTION
The underlying bug is a problem with ansible (https://github.com/ansible/ansible/issues/9260).  This bug is responsible for https://github.com/Capgemini/Apollo/issues/679.

The workaround for this issue is to simply add:

```
- hosts: all
  tasks: []
```

to ```site.xml``` before we try to access ```ansible_default_ipv4```.

Without this workaround, running the bootstrap script on OS X systems seems to consistently fail.