### PR TITLE
Support single availability zone on aws

### DIFF
--- a/terraform/aws/private-cloud/main.tf
+++ b/terraform/aws/private-cloud/main.tf
@@ -4,6 +4,8 @@ variable "public_key_file" { default = "~/.ssh/id_rsa_aws.pub" }
 variable "private_key_file" { default = "~/.ssh/id_rsa_aws.pem" }
 variable "region" { default = "eu-west-1" }
 variable "availability_zones" { default = "eu-west-1a,eu-west-1b,eu-west-1c" }
+variable "public_subnets" { default = "10.0.101.0/24,10.0.102.0/24,10.0.103.0/24" }
+variable "private_subnets" { default = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24" }
 variable "vpc_cidr_block" { default = "10.0.0.0/16" }
 variable "coreos_channel" { default = "stable" }
 variable "etcd_discovery_url_file" { default = "etcd_discovery_url.txt" }
@@ -27,8 +29,8 @@ module "vpc" {
   name                = "default"
 
   cidr                = "${var.vpc_cidr_block}"
-  private_subnets     = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24"
-  public_subnets      = "10.0.101.0/24,10.0.102.0/24,10.0.103.0/24"
+  private_subnets     = "${var.private_subnets}"
+  public_subnets      = "${var.public_subnets}"
   bastion_instance_id = "${aws_instance.bastion.id}"
 
   azs                 = "${var.availability_zones}"

--- a/terraform/aws/public-cloud/main.tf
+++ b/terraform/aws/public-cloud/main.tf
@@ -3,6 +3,7 @@ variable "secret_key" {}
 variable "public_key_file" { default = "~/.ssh/id_rsa_aws.pub" }
 variable "region" { default = "eu-west-1" }
 variable "availability_zones" { default = "eu-west-1a,eu-west-1b,eu-west-1c" }
+variable "public_subnets" { default = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24" }
 variable "coreos_channel" { default = "stable" }
 variable "etcd_discovery_url_file" { default = "etcd_discovery_url.txt" }
 variable "masters" { default = "3" }
@@ -47,7 +48,7 @@ module "public_subnet" {
   source = "github.com/terraform-community-modules/tf_aws_public_subnet"
 
   name   = "public"
-  cidrs  = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24"
+  cidrs  = "${var.public_subnets}"
   azs    = "${var.availability_zones}"
   vpc_id = "${aws_vpc.default.id}"
   igw_id = "${module.igw.igw_id}"


### PR DESCRIPTION
Allow subnets to be set from environment variables.  This is required to support running in a single availability zone. 

Currently if you try to run in a single az, you get an error with the ELB

Environment variables:
```
export TF_VAR_availability_zones=us-east-1a
```

Error:
```
aws_elb.elb: InvalidConfigurationRequest: ELB cannot be attached to multiple subnets in the same AZ.
```

With this pull request, you can successfully run in a single az by just setting both availability zone and subnets:
```
export TF_VAR_availability_zones=us-east-1a
export TF_VAR_public_subnets=10.0.1.0/24
```

BTW, why would I want to run in a single AZ?  I'm trying to set up Flocker, which only supports a single AZ.  If anyone has gotten this working please send me a message.